### PR TITLE
File support

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -215,6 +215,7 @@ module Fastlane
 
         true
       end
+
       def self.post_notes(app_id, release_id, release_notes)
         payload = { releaseNotes: { releaseNotes: release_notes } }
         if release_notes.nil? || release_notes.empty?

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -44,6 +44,7 @@ module Fastlane
           return
         end
         post_notes(app_id, release_id, params[:release_notes])
+        enable_access(app_id, release_id, params[:testers])
       ensure
         cleanup_tempfiles
       end
@@ -215,6 +216,16 @@ module Fastlane
         end
 
         true
+      end
+       def self.enable_access(app_id, release_id, emails)
+        #iterate through the string here and put it in the payload.
+        #payload = {emails: email}
+        #emails = email.gsub!(/\s+/, '').split(",")
+       payload = {emails: emails.gsub!(/\s+/, '').split(",")}
+        connection.post("#{PATH}#{app_id}/releases/#{release_id}/enable_access", payload.to_json) do |request|
+          request.headers["Authorization"] = "Bearer " + auth_token
+        end
+        UI.message("Successfully sent testers apk/ipa.")
       end
 
       def self.post_notes(app_id, release_id, release_notes)

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -43,10 +43,8 @@ module Fastlane
         if release_id.nil?
           return
         end
-        post_notes(app_id, release_id, params[:release_notes])
-        enable_access(app_id, release_id, params[:testers])
-      ensure
-        cleanup_tempfiles
+        release_notes = get_value_from_value_or_file(params[:release_notes], params[:release_notes_file])
+        post_notes(app_id, release_id, release_notes)
       end
 
       def self.connection
@@ -217,17 +215,6 @@ module Fastlane
 
         true
       end
-       def self.enable_access(app_id, release_id, emails)
-        #iterate through the string here and put it in the payload.
-        #payload = {emails: email}
-        #emails = email.gsub!(/\s+/, '').split(",")
-       payload = {emails: emails.gsub!(/\s+/, '').split(",")}
-        connection.post("#{PATH}#{app_id}/releases/#{release_id}/enable_access", payload.to_json) do |request|
-          request.headers["Authorization"] = "Bearer " + auth_token
-        end
-        UI.message("Successfully sent testers apk/ipa.")
-      end
-
       def self.post_notes(app_id, release_id, release_notes)
         payload = { releaseNotes: { releaseNotes: release_notes } }
         if release_notes.nil? || release_notes.empty?

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
@@ -15,5 +15,5 @@ module ErrorMessage
   APP_NOT_ONBOARDED_ERROR = "App Distribution not onboarded"
   GET_APP_NO_CONTACT_EMAIL_ERROR = "App Distribution could not find a contact email associated with this app. Contact Email"
   INVALID_APP_ID = "App Distribution could not find your app. Make sure to onboard your app by pressing the \"Get started\" button on the App Distribution page in the Firebase console: https://console.firebase.google.com/project/_/appdistribution. App ID"
-  INVALID_PATH = "Error reading in your file. Please check that the path and file format are correct. Path"
+  INVALID_PATH = "Could not read content from"
 end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
@@ -15,4 +15,5 @@ module ErrorMessage
   APP_NOT_ONBOARDED_ERROR = "App Distribution not onboarded"
   GET_APP_NO_CONTACT_EMAIL_ERROR = "App Distribution could not find a contact email associated with this app. Contact Email"
   INVALID_APP_ID = "App Distribution could not find your app. Make sure to onboard your app by pressing the \"Get started\" button on the App Distribution page in the Firebase console: https://console.firebase.google.com/project/_/appdistribution. App ID"
+  INVALID_PATH = "Error reading in your file. Please check that the path and file format are correct. Path"
 end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -6,10 +6,8 @@ module Fastlane
 
   module Helper
     module FirebaseAppDistributionHelper
-      # Should we throw an exception if path is empty or not passed in? Check gradle plugin.
       def get_value_from_value_or_file(value, path)
         if value.nil? || value.empty? && !path.nil? || !path.empty?
-          UI.message(!path.empty?)
           if File.exist?(path)
             return File.open(path).read
           end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -8,11 +8,12 @@ module Fastlane
     module FirebaseAppDistributionHelper
       # Should we throw an exception if path is empty or not passed in? Check gradle plugin.
       def get_value_from_value_or_file(value, path)
-        if value.nil? || value.empty?
+        if value.nil? || value.empty? && !path.nil? || !path.empty?
+          UI.message(!path.empty?)
           if File.exist?(path)
             return File.open(path).read
           end
-          return ""
+          UI.crash!("#{ErrorMessage::APK_NOT_FOUND}: #{path}")
         end
         value
       end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -6,62 +6,17 @@ module Fastlane
 
   module Helper
     module FirebaseAppDistributionHelper
-      def testers_flag(params)
-        file_flag_if_supplied("--testers-file", "testers", params)
+      # Should we throw an exception if path is empty or not passed in? Check gradle plugin. 
+      def get_value_from_value_or_file(value, path)
+          if value.nil? || value.empty? 
+            if File.exist?(path)
+              return File.open(path).read
+            end
+            return ""
+          end 
+          value
       end
-
-      def groups_flag(params)
-        file_flag_if_supplied("--groups-file", "groups", params)
-      end
-
-      def release_notes_flag(params)
-        file_flag_if_supplied("--release-notes-file", "release_notes", params)
-      end
-
-      def file_flag_if_supplied(flag, param_name, params)
-        file = params["#{param_name}_file".to_sym]
-        file ||= file_for_contents(param_name.to_sym, params)
-
-        if file
-          return "#{flag} #{file}"
-        end
-      end
-
-      def flag_value_if_supplied(flag, param_name, params)
-        "#{flag} #{params[param_name]}" if params[param_name]
-      end
-
-      def flag_if_supplied(flag, param_name, params)
-        flag if params[param_name]
-      end
-
-      ##
-      # always return a file for a given content
-      def file_for_contents(parameter_name, params)
-        if @tempfiles.nil?
-          @tempfiles = []
-        end
-
-        contents = params[parameter_name]
-        return nil if contents.nil?
-
-        file = Tempfile.new(parameter_name.to_s)
-        file.write(contents)
-        file.close
-        @tempfiles << file
-
-        file.path
-      end
-
-      def cleanup_tempfiles
-        return if @tempfiles.nil?
-        @tempfiles.each(&:unlink)
-      end
-
-      def parse_plist(path)
-        CFPropertyList.native_types(CFPropertyList::List.new(file: path).value)
-      end
-
+      
       def get_ios_app_id_from_archive(path)
         app_path = parse_plist("#{path}/Info.plist")["ApplicationProperties"]["ApplicationPath"]
         UI.shell_error!("can't extract application path from Info.plist at #{path}") if app_path.empty?

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -7,11 +7,12 @@ module Fastlane
   module Helper
     module FirebaseAppDistributionHelper
       def get_value_from_value_or_file(value, path)
-        if value.nil? || value.empty? && !path.nil? || !path.empty?
-          if File.exist?(path)
+        if (value.nil? || value.empty?) && (!path.nil? || !path.empty?)
+          begin
             return File.open(path).read
+          rescue
+            UI.crash!("#{ErrorMessage::INVALID_PATH}: #{path}")
           end
-          UI.crash!("#{ErrorMessage::APK_NOT_FOUND}: #{path}")
         end
         value
       end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -6,17 +6,17 @@ module Fastlane
 
   module Helper
     module FirebaseAppDistributionHelper
-      # Should we throw an exception if path is empty or not passed in? Check gradle plugin. 
+      # Should we throw an exception if path is empty or not passed in? Check gradle plugin.
       def get_value_from_value_or_file(value, path)
-          if value.nil? || value.empty? 
-            if File.exist?(path)
-              return File.open(path).read
-            end
-            return ""
-          end 
-          value
+        if value.nil? || value.empty?
+          if File.exist?(path)
+            return File.open(path).read
+          end
+          return ""
+        end
+        value
       end
-      
+
       def get_ios_app_id_from_archive(path)
         app_path = parse_plist("#{path}/Info.plist")["ApplicationProperties"]["ApplicationPath"]
         UI.shell_error!("can't extract application path from Info.plist at #{path}") if app_path.empty?

--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -26,6 +26,23 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
     stubs.verify_stubbed_calls
     Faraday.default_connection = nil
   end
+  describe '#get_value_from_value_or_file' do
+    it 'should return the release notes string' do
+      expect(Fastlane::Actions::FirebaseAppDistributionAction.get_value_from_value_or_file("Hello World", "")).to eq("Hello World")
+    end
+
+    it 'should return the release notes from file' do
+      expect(File).to receive(:exist?).and_return(true)
+      expect(File).to receive(:open)
+        .with("release_notes_path")
+        .and_return(fake_binary)
+      expect(Fastlane::Actions::FirebaseAppDistributionAction.get_value_from_value_or_file("", "release_notes_path")).to eq("Hello World")
+    end
+    it 'should raise an error due to invalid release notes path ' do
+      expect { Fastlane::Actions::FirebaseAppDistributionAction.get_value_from_value_or_file("", "invalid_release_notes_path") }
+        .to raise_error("#{ErrorMessage::APK_NOT_FOUND}: invalid_release_notes_path")
+    end
+  end
 
   describe '#get_upload_token' do
     it 'should make a GET call to the app endpoint and return the upload token' do

--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -26,21 +26,25 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
     stubs.verify_stubbed_calls
     Faraday.default_connection = nil
   end
+
   describe '#get_value_from_value_or_file' do
     it 'should return the release notes string' do
       expect(Fastlane::Actions::FirebaseAppDistributionAction.get_value_from_value_or_file("Hello World", "")).to eq("Hello World")
     end
 
     it 'should return the release notes from file' do
-      expect(File).to receive(:exist?).and_return(true)
       expect(File).to receive(:open)
         .with("release_notes_path")
         .and_return(fake_binary)
       expect(Fastlane::Actions::FirebaseAppDistributionAction.get_value_from_value_or_file("", "release_notes_path")).to eq("Hello World")
     end
+
     it 'should raise an error due to invalid release notes path ' do
+      expect(File).to receive(:open)
+        .with("invalid_release_notes_path")
+        .and_raise(Errno::ENOENT.new("file not found"))
       expect { Fastlane::Actions::FirebaseAppDistributionAction.get_value_from_value_or_file("", "invalid_release_notes_path") }
-        .to raise_error("#{ErrorMessage::APK_NOT_FOUND}: invalid_release_notes_path")
+        .to raise_error("#{ErrorMessage::INVALID_PATH}: invalid_release_notes_path")
     end
   end
 


### PR DESCRIPTION
Adding in File support for the parameters. This allows users to pass in a file as a parameters for either for access or for release notes. 