### PR TITLE
Use binary path to determine path, if none set

### DIFF
--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -1,0 +1,20 @@
+describe Fastlane::Actions::FirebaseAppDistributionAction do
+  let(:action) { Fastlane::Actions::FirebaseAppDistributionAction }
+  describe '#platform_from_path' do
+    it 'returns :android when the binary is an APK' do
+      expect(action.platform_from_path('/path/to/your_binary.apk')).to eq(:android)
+    end
+
+    it 'returns :ios when the binary is an IPA' do
+      expect(action.platform_from_path('/path/to/your_binary.ipa')).to eq(:ios)
+    end
+
+    it 'returns nil when the binary is neither IPA nor APK' do
+      expect(action.platform_from_path('/path/to/your_binary.txt')).to be_nil
+    end
+
+    it 'returns nil when the binary path is nil' do
+      expect(action.platform_from_path(nil)).to be_nil
+    end
+  end
+end

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -15,9 +15,12 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
   end
 
   before(:each) do
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open)
       .with(fake_binary_path)
       .and_return(fake_binary)
+
+    allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?)
       .with(fake_binary_path)
       .and_return(true)

--- a/spec/firebase_app_distribution_auth_client_spec.rb
+++ b/spec/firebase_app_distribution_auth_client_spec.rb
@@ -23,6 +23,7 @@ describe Fastlane::Auth::FirebaseAppDistributionAuthClient do
     allow(fake_service_creds).to receive(:fetch_access_token!)
       .and_return(payload)
 
+    allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open)
       .and_return(fake_binary)
     allow(fake_binary).to receive(:read)

--- a/spec/firebase_app_distribution_helper_spec.rb
+++ b/spec/firebase_app_distribution_helper_spec.rb
@@ -6,6 +6,7 @@ describe Fastlane::Helper::FirebaseAppDistributionHelper do
   let(:plist) { double("plist") }
 
   before(:each) do
+    allow(File).to receive(:open).and_call_original
     allow(fake_binary).to receive(:read).and_return("Hello World")
   end
 


### PR DESCRIPTION
Previously we relied only on the lane context to get the platform. This was causing a surprising number of `unknown` platforms to show up in our metrics. In the Firebase CLI we use the binary file type exclusively to determine the platform. Here we'll use it as a backup if the lane context isn't set.

This also:
- Fixes some failing tests (for me locally, anyway) due to not calling through when mocking the `File` object
- Removes the unnecessary memoization of the lane platform, since it's just a hash lookup