### PR TITLE
Deprecate the firebase_cli_path param

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -105,9 +105,9 @@ module Fastlane
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :firebase_cli_path,
+                                       deprecated: "This plugin no longer uses the Firebase CLI",
                                        env_name: "FIREBASEAPPDISTRO_FIREBASE_CLI_PATH",
                                        description: "The absolute path of the firebase cli command",
-                                       optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :groups,
                                        env_name: "FIREBASEAPPDISTRO_GROUPS",
@@ -174,18 +174,6 @@ module Fastlane
             )
           CODE
         ]
-      end
-
-      ## TODO: figure out if we can surpress color output.
-      def self.is_firebasecmd_supported?(cmd)
-        outerr, status = Open3.capture2e(cmd, "--non-interactive", FIREBASECMD_ACTION, "--help")
-        return false unless status.success?
-
-        if outerr =~ /is not a Firebase command/
-          return false
-        end
-
-        true
       end
     end
   end


### PR DESCRIPTION
Prints the message `Using deprecated option: '--firebase_cli_path' (This plugin no longer uses the Firebase CLI)` when the parameter is used:

![image](https://user-images.githubusercontent.com/10420620/91756224-65955d80-eb9a-11ea-9f8a-62b6d0b8e283.png)


This also removes an unused method that was originally used by this parameter.