### PR TITLE
Fix binary upload on Windows

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -89,7 +89,7 @@ module Fastlane
         if binary_path.nil? || !File.exist?(binary_path)
           UI.crash!("#{ErrorMessage.binary_not_found(@binary_type)}: #{binary_path}")
         end
-        binary_hash = Digest::SHA256.hexdigest(File.open(binary_path).read)
+        binary_hash = Digest::SHA256.hexdigest(read_binary(binary_path))
 
         begin
           response = connection.get(v1_apps_url(app_id)) do |request|
@@ -114,7 +114,7 @@ module Fastlane
       #
       # Throws a user_error if an invalid app id is passed in, or if the binary file does not exist
       def upload_binary(app_id, binary_path, platform)
-        connection.post(binary_upload_url(app_id), File.open(binary_path).read) do |request|
+        connection.post(binary_upload_url(app_id), read_binary(binary_path)) do |request|
           request.headers["Authorization"] = "Bearer " + @auth_token
           request.headers["X-APP-DISTRO-API-CLIENT-ID"] = "fastlane"
           request.headers["X-APP-DISTRO-API-CLIENT-TYPE"] =  platform
@@ -222,6 +222,11 @@ module Fastlane
           conn.response(:raise_error) # raise_error middleware will run before the json middleware
           conn.adapter(Faraday.default_adapter)
         end
+      end
+
+      def read_binary(path)
+        # File must be read in binary mode to work on Windows
+        File.open(path, 'rb').read
       end
     end
   end

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -17,7 +17,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
   before(:each) do
     allow(File).to receive(:open).and_call_original
     allow(File).to receive(:open)
-      .with(fake_binary_path)
+      .with(fake_binary_path, "rb")
       .and_return(fake_binary)
 
     allow(File).to receive(:exist?).and_call_original
@@ -126,7 +126,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
 
     it 'crashes when given an invalid binary_path' do
       expect(File).to receive(:open)
-        .with("invalid_binary_path")
+        .with("invalid_binary_path", "rb")
         .and_raise(Errno::ENOENT.new("file not found"))
       expect { api_client.upload_binary("app_id", "invalid_binary_path", "android") }
         .to raise_error("#{ErrorMessage.binary_not_found('APK')}: invalid_binary_path")


### PR DESCRIPTION
Should fix https://github.com/fastlane/fastlane-plugin-firebase_app_distribution/issues/146

I was able to reproduce the issue on Windows, and this fixes it. The issue is probably the EOL conversion:

```
"b"  |  Binary file mode (may appear with
     |  any of the key letters listed above).
     |  Suppresses EOL <-> CRLF conversion on Windows. And
     |  sets external encoding to ASCII-8BIT unless explicitly
     |  specified.
```

Tested by uploading new iOS and Android distributions and verifying that the uploads succeed and the apps function correctly.