### PR TITLE
Get binary path from platform, and platform from app ID

### DIFF
--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -1,20 +1,38 @@
 describe Fastlane::Actions::FirebaseAppDistributionAction do
   let(:action) { Fastlane::Actions::FirebaseAppDistributionAction }
-  describe '#platform_from_path' do
-    it 'returns :android when the binary is an APK' do
-      expect(action.platform_from_path('/path/to/your_binary.apk')).to eq(:android)
+  describe '#platform_from_app_id' do
+    it 'returns :android for an Android app' do
+      expect(action.platform_from_app_id('1:1234567890:android:321abc456def7890')).to eq(:android)
     end
 
-    it 'returns :ios when the binary is an IPA' do
-      expect(action.platform_from_path('/path/to/your_binary.ipa')).to eq(:ios)
+    it 'returns :ios for an iOS app' do
+      expect(action.platform_from_app_id('1:1234567890:ios:321abc456def7890')).to eq(:ios)
     end
 
-    it 'returns nil when the binary is neither IPA nor APK' do
-      expect(action.platform_from_path('/path/to/your_binary.txt')).to be_nil
+    it 'returns nil for a Web app' do
+      expect(action.platform_from_app_id('1:65211879909:web:3ae38ef1cdcb2e01fe5f0c')).to be_nil
+    end
+  end
+
+  describe '#binary_path_from_platform' do
+    it 'returns the ipa_path for an iOS app' do
+      expect(action.binary_path_from_platform(:ios, '/ipa/path', '/apk/path')).to eq('/ipa/path')
     end
 
-    it 'returns nil when the binary path is nil' do
-      expect(action.platform_from_path(nil)).to be_nil
+    it 'returns the apk_path for an Android app' do
+      expect(action.binary_path_from_platform(:android, '/ipa/path', '/apk/path')).to eq('/apk/path')
+    end
+
+    it 'returns the ipa_path by default when there is no platform' do
+      expect(action.binary_path_from_platform(nil, '/ipa/path', '/apk/path')).to eq('/ipa/path')
+    end
+
+    it 'falls back on the apk_path when there is no platform and no ipa_path' do
+      expect(action.binary_path_from_platform(nil, nil, '/apk/path')).to eq('/apk/path')
+    end
+
+    it 'returns nil when there is no platform and no paths' do
+      expect(action.binary_path_from_platform(nil, nil, nil)).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
Previously if no platform is set, we would get the binary path using a combination of the parameters passed in, and searching for an IPA or APK. Then we would determine the platform from the binary path.

This leads to bugs like https://github.com/fastlane/fastlane-plugin-firebase_app_distribution/issues/151, because if for example we find an IPA in the root directory, we will upload that binary regardless of whether or not apk_path is set.

It will be more reliable to get the platform from the app ID, and they use that to determine which path to use.