### PR TITLE
Do not use platform before it's initialized

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -23,11 +23,9 @@ module Fastlane
 
         if params[:app] # Set app_id if it is specified as a parameter
           app_id = params[:app]
-        elsif platform == :ios
-          archive_path = Actions.lane_context[SharedValues::XCODEBUILD_ARCHIVE]
-          if archive_path
-            app_id = get_ios_app_id_from_archive_plist(archive_path, params[:googleservice_info_plist_path])
-          end
+        elsif xcode_archive_path
+          plist_path = params[:googleservice_info_plist_path]
+          app_id = get_ios_app_id_from_archive_plist(xcode_archive_path, plist_path)
         end
         if app_id.nil?
           UI.crash!(ErrorMessage::MISSING_APP_ID)
@@ -66,6 +64,14 @@ module Fastlane
       # supports markdown.
       def self.details
         "Release your beta builds with Firebase App Distribution"
+      end
+
+      def self.xcode_archive_path
+        # prevents issues on cross-platform build environments where an XCode build happens within
+        # the same lane
+        return nil if lane_platform == :android
+
+        Actions.lane_context[SharedValues::XCODEBUILD_ARCHIVE]
       end
 
       def self.lane_platform

--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -1,3 +1,5 @@
+require 'fastlane/action'
+
 describe Fastlane::Actions::FirebaseAppDistributionAction do
   let(:action) { Fastlane::Actions::FirebaseAppDistributionAction }
   describe '#platform_from_app_id' do
@@ -33,6 +35,28 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
 
     it 'returns nil when there is no platform and no paths' do
       expect(action.binary_path_from_platform(nil, nil, nil)).to eq(nil)
+    end
+  end
+
+  describe '#xcode_archive_path' do
+    it 'returns the archive path is set, and platform is not Android' do
+      allow(Fastlane::Actions).to receive(:lane_context).and_return({
+        XCODEBUILD_ARCHIVE: '/path/to/archive'
+      })
+      expect(action.xcode_archive_path).to eq('/path/to/archive')
+    end
+
+    it 'returns nil if platform is Android' do
+      allow(Fastlane::Actions).to receive(:lane_context).and_return({
+        XCODEBUILD_ARCHIVE: '/path/to/archive',
+        PLATFORM_NAME: :android
+      })
+      expect(action.xcode_archive_path).to be_nil
+    end
+
+    it 'returns nil if the archive path is not set' do
+      allow(Fastlane::Actions).to receive(:lane_context).and_return({})
+      expect(action.xcode_archive_path).to be_nil
     end
   end
 end


### PR DESCRIPTION
https://github.com/fastlane/fastlane-plugin-firebase_app_distribution/pull/152 introduced a bug where if you don't set the app ID, we try to use the platform before the variable has been set.

Instead, we really just need to see if xcode_archive_path is set. However, because some folks might be building in cross-platform environments, we double check that the platform is not set to Android in the lane context.