### PR TITLE
Version bump for 0.2.2.pre.2

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/version.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FirebaseAppDistribution
-    VERSION = "0.2.2.pre.1"
+    VERSION = "0.2.2.pre.2"
   end
 end


### PR DESCRIPTION
Includes:
- Fix for https://github.com/fastlane/fastlane-plugin-firebase_app_distribution/issues/154
- Adds the `--googleservice_info_plist_path` parameter: https://github.com/fastlane/fastlane-plugin-firebase_app_distribution/pull/46