### PR TITLE
Show error message when posting release notes fails

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/client/error_response.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/error_response.rb
@@ -1,0 +1,16 @@
+module Fastlane
+  module Client
+    class ErrorResponse
+      attr_accessor :code, :message, :status
+
+      def initialize(response)
+        unless response[:body].nil? || response[:body].empty?
+          response_body = JSON.parse(response[:body], symbolize_names: true)
+          @code = response_body[:error][:code]
+          @message = response_body[:error][:message]
+          @status = response_body[:error][:status]
+        end
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -1,5 +1,6 @@
 require 'fastlane_core/ui/ui'
 require_relative '../actions/firebase_app_distribution_login'
+require_relative '../client/error_response'
 
 module Fastlane
   module Client
@@ -77,8 +78,9 @@ module Fastlane
           end
         rescue Faraday::ResourceNotFound
           UI.user_error!("#{ErrorMessage::INVALID_APP_ID}: #{app_id}")
-          # rescue Faraday::ClientError
-          #   UI.user_error!("#{ErrorMessage::INVALID_RELEASE_ID}: #{release_id}")
+        rescue Faraday::ClientError => e
+          error = ErrorResponse.new(e.response)
+          UI.user_error!("#{ErrorMessage::INVALID_RELEASE_NOTES}: #{error.message}")
         end
         UI.success("✅ Posted release notes.")
       end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
@@ -14,6 +14,7 @@ module ErrorMessage
   INVALID_PATH = "Could not read content from"
   INVALID_TESTERS = "Could not enable access for testers. Check that the groups exist and the tester emails are formatted correctly"
   INVALID_RELEASE_ID = "App distribution failed to fetch release with id"
+  INVALID_RELEASE_NOTES = "Failed to add release notes"
   SERVICE_CREDENTIALS_ERROR = "App Distribution could not generate credentials from the service credentials file specified. Service Account Path"
 
   def self.binary_not_found(binary_type)

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -298,7 +298,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
       api_client.post_notes("app_id", "release_id", nil)
     end
 
-    it 'crashes when given an invalid app_id' do
+    it 'fails when given an invalid app_id' do
       stubs.post("/v1alpha/apps/invalid_app_id/releases/release_id/notes", release_notes, headers) do |env|
         [
           404,
@@ -308,6 +308,18 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
       end
       expect { api_client.post_notes("invalid_app_id", "release_id", "release_notes") }
         .to raise_error("#{ErrorMessage::INVALID_APP_ID}: invalid_app_id")
+    end
+
+    it 'fails with error message from response when a client error is thrown' do
+      stubs.post("/v1alpha/apps/app_id/releases/release_id/notes", release_notes, headers) do |env|
+        [
+          400,
+          {},
+          { error: { message: "client error response message" } }.to_json
+        ]
+      end
+      expect { api_client.post_notes("app_id", "release_id", "release_notes") }
+        .to raise_error("#{ErrorMessage::INVALID_RELEASE_NOTES}: client error response message")
     end
 
     # BUG: 500 errors causes a ClientError locally but ServerError on CircleCI specs, causing this test to be flaky.


### PR DESCRIPTION
Parse error response of call to create release notes and display error message.

<img width="623" alt="Screen Shot 2020-10-09 at 9 32 46 AM" src="https://user-images.githubusercontent.com/401051/95589198-69769400-0a12-11eb-84af-6a3ed8ad2e29.png">
