### PR TITLE
Add support for debug logging

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -26,7 +26,7 @@ module Fastlane
         binary_path = binary_path_from_platform(platform, params[:ipa_path], params[:apk_path])
 
         auth_token = fetch_auth_token(params[:service_credentials_file], params[:firebase_cli_token])
-        fad_api_client = Client::FirebaseAppDistributionApiClient.new(auth_token, platform)
+        fad_api_client = Client::FirebaseAppDistributionApiClient.new(auth_token, platform, params[:debug])
 
         release_id = fad_api_client.upload(app_id, binary_path, platform.to_s)
         if release_id.nil?

--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -229,7 +229,7 @@ module Fastlane
         @connection ||= Faraday.new(url: BASE_URL) do |conn|
           conn.response(:json, parser_options: { symbolize_names: true })
           conn.response(:raise_error) # raise_error middleware will run before the json middleware
-          conn.response(:logger, nil, { log_level: :debug }) if @debug
+          conn.response(:logger, nil, { headers: false, bodies: { response: true }, log_level: :debug }) if @debug
           conn.adapter(Faraday.default_adapter)
         end
       end

--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -15,7 +15,7 @@ module Fastlane
       APPLICATION_JSON = "application/json"
       APPLICATION_OCTET_STREAM = "application/octet-stream"
 
-      def initialize(auth_token, platform, debug=false)
+      def initialize(auth_token, platform, debug = false)
         @auth_token = auth_token
         @debug = debug
 

--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -14,8 +14,9 @@ module Fastlane
       APPLICATION_JSON = "application/json"
       APPLICATION_OCTET_STREAM = "application/octet-stream"
 
-      def initialize(auth_token, platform)
+      def initialize(auth_token, platform, debug=false)
         @auth_token = auth_token
+        @debug = debug
 
         if platform.nil?
           @binary_type = "IPA/APK"
@@ -228,6 +229,7 @@ module Fastlane
         @connection ||= Faraday.new(url: BASE_URL) do |conn|
           conn.response(:json, parser_options: { symbolize_names: true })
           conn.response(:raise_error) # raise_error middleware will run before the json middleware
+          conn.response(:logger, nil, { log_level: :debug }) if @debug
           conn.adapter(Faraday.default_adapter)
         end
       end


### PR DESCRIPTION
Before `v.0.2.0` we passed the `debug` parameter to the Firebase CLI and it printed verbose output. Now that there is no longer a dependency on the Firebase CLI , this parameter wasn't being used. This change adds support for debug logging the request and the response body.

<img width="941" alt="Screen Shot 2020-10-09 at 9 47 29 AM" src="https://user-images.githubusercontent.com/401051/95591433-48637280-0a15-11eb-81c2-0db1641655ef.png">