### PR TITLE
Removed the duplicate tester emails to prevent error 500

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -38,7 +38,7 @@ module Fastlane
 
         testers = get_value_from_value_or_file(params[:testers], params[:testers_file])
         groups = get_value_from_value_or_file(params[:groups], params[:groups_file])
-        emails = string_to_array(testers)
+        emails = string_to_array(testers).uniq
         group_ids = string_to_array(groups)
         fad_api_client.enable_access(app_id, release_id, emails, group_ids)
         UI.success("🎉 App Distribution upload finished successfully.")


### PR DESCRIPTION
I just stumbled across an edge case in the enable_access step.
Firebase returns an error 500 if there are duplicate email addresses, so I removed the duplicates.