### PR TITLE
Retry transient server errors automatically

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -201,6 +201,16 @@ module Fastlane
         return UploadStatusResponse.new(response.body)
       end
 
+      def self.configure_connection(conn) # :nodoc:
+        conn.response(:json, parser_options: { symbolize_names: true })
+        conn.response(:raise_error) # raise_error middleware will run before the json middleware
+        # The Firebase API seems to use the POST verb where it should use PUT, and all of those
+        # are idempotent. Retry them since they can randomly fail in the wild.
+        conn.request(:retry, { max: 5,
+                               retry_statuses: [500, 501, 502, 503],
+                               methods: %i[delete get head options put post] })
+      end
+
       private
 
       def v1_apps_url(app_id)
@@ -229,8 +239,7 @@ module Fastlane
 
       def connection
         @connection ||= Faraday.new(url: BASE_URL) do |conn|
-          conn.response(:json, parser_options: { symbolize_names: true })
-          conn.response(:raise_error) # raise_error middleware will run before the json middleware
+          self.class.configure_connection(conn)
           conn.response(:logger, nil, { headers: false, bodies: { response: true }, log_level: :debug }) if @debug
           conn.adapter(Faraday.default_adapter)
         end

--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -206,9 +206,12 @@ module Fastlane
         conn.response(:raise_error) # raise_error middleware will run before the json middleware
         # The Firebase API seems to use the POST verb where it should use PUT, and all of those
         # are idempotent. Retry them since they can randomly fail in the wild.
-        conn.request(:retry, { max: 5,
-                               retry_statuses: [500, 501, 502, 503],
-                               methods: %i[delete get head options put post] })
+        conn.request(:retry, { retry_statuses: [500, 501, 502, 503],
+                               methods: %i[delete get head options put post],
+                               max: 5,
+                               interval: 0.05,
+                               interval_randomness: 0.5,
+                               backoff_factor: 2 })
       end
 
       private

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -150,6 +150,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
         responses.shift
       end
       api_client.upload_binary("app_id", fake_binary_path, "android")
+      expect(responses).to be_empty, "the upload should have been retried after the initial failure"
     end
   end
 


### PR DESCRIPTION
Sometimes, the Firebase APIs will return an HTTP 500 or 503 server error for temporary or transient errors. Retrying the same request can help prevent these one-off errors from failing a whole CI build.

This patch also centralizes Faraday configuration so it matches between real life and the test suite rather than being duplicated.

As an example of the kind of issue this resolves, the following error:

```
D, [2020-11-17T14:40:30.351373 #1153] DEBUG -- request: POST https://firebaseappdistribution.googleapis.com/app-binary-uploads?app_id=1%3Ascrubbed
D, [2020-11-17T14:40:31.696651 #1153] DEBUG -- response: Status 503
D, [2020-11-17T14:40:31.696739 #1153] DEBUG -- response: Service Unavailable
```

would previously result in a Fastlane failure:

```
Faraday::ServerError: [!] the server responded with status 503
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/faraday-1.0.1/lib/faraday/response/raise_error.rb:34:in `on_complete'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/faraday-1.0.1/lib/faraday/response.rb:12:in `block in call'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/faraday-1.0.1/lib/faraday/response.rb:65:in `on_complete'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/faraday-1.0.1/lib/faraday/response.rb:11:in `call'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/faraday_middleware-1.0.0/lib/faraday_middleware/response_middleware.rb:36:in `call'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/faraday-1.0.1/lib/faraday/rack_builder.rb:153:in `build_response'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/faraday-1.0.1/lib/faraday/connection.rb:492:in `run_request'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/faraday-1.0.1/lib/faraday/connection.rb:279:in `post'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-plugin-firebase_app_distribution-0.2.4/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb:127:in `upload_binary'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-plugin-firebase_app_distribution-0.2.4/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb:159:in `upload'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-plugin-firebase_app_distribution-0.2.4/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb:31:in `run'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/runner.rb:263:in `block (2 levels) in execute_action'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/actions/actions_helper.rb:69:in `execute_action'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/runner.rb:255:in `block in execute_action'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/runner.rb:229:in `chdir'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/runner.rb:229:in `execute_action'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/runner.rb:157:in `trigger_action_by_name'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/fast_file.rb:159:in `method_missing'
  Fastfile:41:in `distribute_build'
  Fastfile:154:in `block (2 levels) in parsing_binding'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/lane.rb:33:in `call'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/runner.rb:49:in `block in execute'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/runner.rb:45:in `chdir'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/runner.rb:45:in `execute'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/lane_manager.rb:47:in `cruise_lane'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/command_line_handler.rb:36:in `handle'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/commands_generator.rb:108:in `block (2 levels) in run'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/commander-fastlane-4.4.6/lib/commander/command.rb:178:in `call'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/commander-fastlane-4.4.6/lib/commander/command.rb:153:in `run'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/commander-fastlane-4.4.6/lib/commander/runner.rb:476:in `run_active_command'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:76:in `run!'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/commander-fastlane-4.4.6/lib/commander/delegates.rb:15:in `run!'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/commands_generator.rb:352:in `run'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/commands_generator.rb:41:in `start'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/cli_tools_distributor.rb:119:in `take_off'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/gems/fastlane-2.162.0/bin/fastlane:23:in `<top (required)>'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/bin/fastlane:23:in `load'
  /Users/distiller/project/vendor/bundle/ruby/2.7.0/bin/fastlane:23:in `<top (required)>'
```