### PR TITLE
Add support for uploading AAB's

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -113,15 +113,6 @@ module Fastlane
       end
 
       def self.available_options
-        if lane_platform == :ios || lane_platform.nil?
-          ipa_path_default = Dir["*.ipa"].sort_by { |x| File.mtime(x) }.last
-        end
-
-        if lane_platform == :android
-          apk_path_default = Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-release.apk")].last
-          aab_path_default = Dir["*.aab"].last || Dir[File.join("app", "build", "outputs", "bundle", "release", "app-release.aab")].last
-        end
-
         [
           # iOS Specific
           FastlaneCore::ConfigItem.new(key: :ipa_path,

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -31,7 +31,7 @@ module Fastlane
         fad_api_client = Client::FirebaseAppDistributionApiClient.new(auth_token, params[:debug])
 
         # If binary is an AAB get FULL view of app which includes the aab_state
-        app_view = binary_type == Helper::FirebaseAppDistributionHelper::AAB ? 'FULL' : 'BASIC'
+        app_view = binary_type == :AAB ? 'FULL' : 'BASIC'
         app = fad_api_client.get_app(app_id, app_view)
         validate_app!(app, binary_type)
 
@@ -124,7 +124,7 @@ module Fastlane
           UI.user_error!(ErrorMessage::GET_APP_NO_CONTACT_EMAIL_ERROR)
         end
 
-        if binary_type == Helper::FirebaseAppDistributionHelper::AAB && app.aab_state != App::AabState::ACTIVE && app.aab_state != App::AabState::UNAVAILABLE
+        if binary_type == :AAB && app.aab_state != App::AabState::ACTIVE && app.aab_state != App::AabState::UNAVAILABLE
           case app.aab_state
           when App::AabState::PLAY_ACCOUNT_NOT_LINKED
             UI.user_error!(ErrorMessage::PLAY_ACCOUNT_NOT_LINKED)

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -13,8 +13,6 @@ require_relative '../helper/firebase_app_distribution_auth_client'
 module Fastlane
   module Actions
     class FirebaseAppDistributionAction < Action
-      FIREBASECMD_ACTION = "appdistribution:distribute".freeze
-
       extend Auth::FirebaseAppDistributionAuthClient
       extend Helper::FirebaseAppDistributionHelper
 
@@ -23,12 +21,21 @@ module Fastlane
 
         app_id = app_id_from_params(params)
         platform = lane_platform || platform_from_app_id(app_id)
-        binary_path = binary_path(platform, params)
+
+        binary_path = get_binary_path(platform, params)
+        UI.user_error!("Couldn't find binary") if binary_path.nil?
+        UI.user_error!("Couldn't find binary at path #{binary_path}") unless File.exist?(binary_path)
+        binary_type = binary_type_from_path(binary_path)
 
         auth_token = fetch_auth_token(params[:service_credentials_file], params[:firebase_cli_token])
         fad_api_client = Client::FirebaseAppDistributionApiClient.new(auth_token, params[:debug])
 
-        release_id = fad_api_client.upload(app_id, binary_path, platform.to_s)
+        # If binary is an AAB get FULL view of app which includes the aab_state
+        app_view = binary_type == Helper::FirebaseAppDistributionHelper::AAB ? 'FULL' : 'BASIC'
+        app = fad_api_client.get_app(app_id, app_view)
+        validate_app!(app, binary_type)
+
+        release_id = fad_api_client.upload(app.project_number, app_id, binary_path, platform.to_s)
         if release_id.nil?
           return
         end
@@ -90,7 +97,7 @@ module Fastlane
         end
       end
 
-      def self.binary_path(platform, params)
+      def self.get_binary_path(platform, params)
         if platform == :ios
           return params[:ipa_path] ||
                  Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] ||
@@ -112,6 +119,27 @@ module Fastlane
         end
       end
 
+      def self.validate_app!(app, binary_type)
+        if app.contact_email.nil? || app.contact_email.strip.empty?
+          UI.user_error!(ErrorMessage::GET_APP_NO_CONTACT_EMAIL_ERROR)
+        end
+
+        if binary_type == Helper::FirebaseAppDistributionHelper::AAB && app.aab_state != App::AabState::ACTIVE && app.aab_state != App::AabState::UNAVAILABLE
+          case app.aab_state
+          when App::AabState::PLAY_ACCOUNT_NOT_LINKED
+            UI.user_error!(ErrorMessage::PLAY_ACCOUNT_NOT_LINKED)
+          when App::AabState::APP_NOT_PUBLISHED
+            UI.user_error!(ErrorMessage::APP_NOT_PUBLISHED)
+          when App::AabState::NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT
+            UI.user_error!(ErrorMessage::NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT)
+          when App::AabState::PLAY_IAS_TERMS_NOT_ACCEPTED
+            UI.user_error!(ErrorMessage::PLAY_IAS_TERMS_NOT_ACCEPTED)
+          else
+            UI.user_error!(ErrorMessage.aab_upload_error(app.aab_state))
+          end
+        end
+      end
+
       def self.available_options
         [
           # iOS Specific
@@ -128,13 +156,12 @@ module Fastlane
           # Android Specific
           FastlaneCore::ConfigItem.new(key: :apk_path,
                                        env_name: "FIREBASEAPPDISTRO_APK_PATH",
-                                       deprecated: "The apk_path parameter is deprecated. Please use android_artifact_path",
+                                       deprecated: "The apk_path parameter is deprecated. Please use android_artifact_path instead",
                                        description: "Path to your APK file",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :android_artifact_path,
                                        env_name: "FIREBASEAPPDISTRO_ANDROID_ARTIFACT_PATH",
-                                       description: "Path to your AAB file",
-                                       default_value_dynamic: true,
+                                       description: "Path to your APK or AAB file",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :android_artifact_type,
                                        env_name: "FIREBASEAPPDISTRO_ANDROID_ARTIFACT_TYPE",

--- a/lib/fastlane/plugin/firebase_app_distribution/client/app.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/app.rb
@@ -1,0 +1,32 @@
+class App
+  # AAB states
+  class AabState
+    UNSPECIFIED = "AAB_STATE_UNSPECIFIED"
+    PLAY_ACCOUNT_NOT_LINKED = "PLAY_ACCOUNT_NOT_LINKED"
+    NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT = "NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT"
+    APP_NOT_PUBLISHED = "APP_NOT_PUBLISHED"
+    PLAY_IAS_TERMS_NOT_ACCEPTED = "PLAY_IAS_TERMS_NOT_ACCEPTED"
+    ACTIVE = "ACTIVE"
+    UNAVAILABLE = "AAB_STATE_UNAVAILABLE"
+  end
+
+  def initialize(response)
+    @response = response
+  end
+
+  def app_id
+    @response[:appId]
+  end
+
+  def project_number
+    @response[:projectNumber]
+  end
+
+  def contact_email
+    @response[:contactEmail]
+  end
+
+  def aab_state
+    @response[:aabState]
+  end
+end

--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -20,11 +20,11 @@ module Fastlane
         @debug = debug
 
         if platform.nil?
-          @binary_type = "IPA/APK"
+          @binary_type = "AAB/APK/IPA"
         elsif platform == :ios
           @binary_type = "IPA"
         else
-          @binary_type = "APK"
+          @binary_type = "AAB/APK"
         end
       end
 
@@ -87,7 +87,7 @@ module Fastlane
       #
       # args
       #   app_id - Firebase App ID
-      #   binary_path - Absolute path to your app's apk/ipa file
+      #   binary_path - Absolute path to your app's aab/apk/ipa file
       #
       # Throws a user_error if an invalid app id is passed in, the binary file does
       # not exist, or invalid auth credentials are used (e.g. wrong project permissions)
@@ -115,7 +115,7 @@ module Fastlane
       #
       # args
       #   app_id - Firebase App ID
-      #   binary_path - Absolute path to your app's apk/ipa file
+      #   binary_path - Absolute path to your app's aab/apk/ipa file
       #   platform - 'android' or 'ios'
       #
       # Throws a user_error if the binary file does not exist
@@ -126,6 +126,8 @@ module Fastlane
           request.headers["X-APP-DISTRO-API-CLIENT-ID"] = "fastlane"
           request.headers["X-APP-DISTRO-API-CLIENT-TYPE"] =  platform
           request.headers["X-APP-DISTRO-API-CLIENT-VERSION"] = Fastlane::FirebaseAppDistribution::VERSION
+          request.headers["X-GOOG-UPLOAD-FILE-NAME"] = File.basename(binary_path)
+          request.headers["X-GOOG-UPLOAD-PROTOCOL"] = "raw"
         end
       rescue Errno::ENOENT # Raised when binary_path file does not exist
         UI.user_error!("#{ErrorMessage.binary_not_found(@binary_type)}: #{binary_path}")
@@ -136,7 +138,7 @@ module Fastlane
       #
       # args
       #   app_id - Firebase App ID
-      #   binary_path - Absolute path to your app's apk/ipa file
+      #   binary_path - Absolute path to your app's aab/apk/ipa file
       #
       # Returns the release_id on a successful release, otherwise returns nil.
       #

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
@@ -16,6 +16,14 @@ module ErrorMessage
   INVALID_RELEASE_ID = "App distribution failed to fetch release with id"
   INVALID_RELEASE_NOTES = "Failed to add release notes"
   SERVICE_CREDENTIALS_ERROR = "App Distribution could not generate credentials from the service credentials file specified. Service Account Path"
+  PLAY_ACCOUNT_NOT_LINKED = "This project is not linked to a Google Play account."
+  APP_NOT_PUBLISHED = "This app is not published in the Google Play console."
+  NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT = "App with matching package name does not exist in Google Play."
+  PLAY_IAS_TERMS_NOT_ACCEPTED = "You must accept the Play Internal App Sharing (IAS) terms to upload AABs."
+
+  def self.aab_upload_error(aab_state)
+    "Failed to process the AAB: #{aab_state}"
+  end
 
   def self.binary_not_found(binary_type)
     "Could not find the #{binary_type}. Make sure you set the #{binary_type} path parameter to point to your #{binary_type}"

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -4,6 +4,19 @@ module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?("UI")
   module Helper
     module FirebaseAppDistributionHelper
+      APK = 'APK'
+      AAB = 'AAB'
+      IPA = 'IPA'
+
+      def binary_type_from_path(binary_path)
+        extension = File.extname(binary_path)
+        return APK if extension == '.apk'
+        return AAB if extension == '.aab'
+        return IPA if extension == '.ipa'
+
+        UI.user_error!("Unsupported distribution file format, should be .ipa, .apk or .aab")
+      end
+
       def get_value_from_value_or_file(value, path)
         if (value.nil? || value.empty?) && !path.nil?
           begin

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -4,15 +4,11 @@ module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?("UI")
   module Helper
     module FirebaseAppDistributionHelper
-      APK = 'APK'
-      AAB = 'AAB'
-      IPA = 'IPA'
-
       def binary_type_from_path(binary_path)
         extension = File.extname(binary_path)
-        return APK if extension == '.apk'
-        return AAB if extension == '.aab'
-        return IPA if extension == '.ipa'
+        return :APK if extension == '.apk'
+        return :AAB if extension == '.aab'
+        return :IPA if extension == '.ipa'
 
         UI.user_error!("Unsupported distribution file format, should be .ipa, .apk or .aab")
       end

--- a/lib/fastlane/plugin/firebase_app_distribution/version.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FirebaseAppDistribution
-    VERSION = "0.2.5"
+    VERSION = "0.2.5.pre.1"
   end
 end

--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -2,6 +2,7 @@ require 'fastlane/action'
 
 describe Fastlane::Actions::FirebaseAppDistributionAction do
   let(:action) { Fastlane::Actions::FirebaseAppDistributionAction }
+  let(:project_number) { '1' }
   let(:ios_app_id) { '1:1234567890:ios:321abc456def7890' }
   let(:android_app_id) { '1:1234567890:android:321abc456def7890' }
 
@@ -19,16 +20,16 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
     end
   end
 
-  describe '#binary_path' do
+  describe '#get_binary_path' do
     describe 'with an iOS app' do
       it 'returns the value for ipa_path' do
-        expect(action.binary_path(:ios, { app: ios_app_id, ipa_path: 'binary.ipa' })).to eq('binary.ipa')
+        expect(action.get_binary_path(:ios, { app: ios_app_id, ipa_path: 'binary.ipa' })).to eq('binary.ipa')
       end
 
       it 'attempts to find them most recent ipa' do
         allow(Dir).to receive('[]').with('*.ipa').and_return(['binary.ipa'])
         allow(File).to receive(:mtime).and_return(0)
-        expect(action.binary_path(:ios, { app: ios_app_id })).to eq('binary.ipa')
+        expect(action.get_binary_path(:ios, { app: ios_app_id })).to eq('binary.ipa')
       end
     end
 
@@ -36,11 +37,11 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
       before { allow(Fastlane::Actions.lane_context).to receive('[]') }
 
       it 'returns the value for apk_path for an Android app' do
-        expect(action.binary_path(:android, { app: android_app_id, apk_path: 'binary.apk' })).to eq('binary.apk')
+        expect(action.get_binary_path(:android, { app: android_app_id, apk_path: 'binary.apk' })).to eq('binary.apk')
       end
 
       it 'returns the value for android_artifact_path for an Android app' do
-        expect(action.binary_path(:android, { app: android_app_id, android_artifact_path: 'binary.apk' })).to eq('binary.apk')
+        expect(action.get_binary_path(:android, { app: android_app_id, android_artifact_path: 'binary.apk' })).to eq('binary.apk')
       end
 
       describe 'when android_artifact_type is not set' do
@@ -48,18 +49,18 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
 
         it 'returns SharedValues::GRADLE_APK_OUTPUT_PATH value' do
           allow(Fastlane::Actions.lane_context).to receive('[]').with(Fastlane::Actions::SharedValues::GRADLE_APK_OUTPUT_PATH).and_return('binary.apk')
-          expect(action.binary_path(:android, params)).to eq('binary.apk')
+          expect(action.get_binary_path(:android, params)).to eq('binary.apk')
         end
 
         it 'attempts to find apk in current director and returns value' do
           allow(Dir).to receive('[]').with('*.apk').and_return(['first-binary.apk', 'last-binary.apk'])
-          expect(action.binary_path(:android, params)).to eq('last-binary.apk')
+          expect(action.get_binary_path(:android, params)).to eq('last-binary.apk')
         end
 
         it 'attempts to find apk in output folder and returns value' do
           allow(Dir).to receive('[]').with('*.apk').and_return([])
           allow(Dir).to receive('[]').with('app/build/outputs/apk/release/app-release.apk').and_return(['first-binary.apk', 'last-binary.apk'])
-          expect(action.binary_path(:android, params)).to eq('last-binary.apk')
+          expect(action.get_binary_path(:android, params)).to eq('last-binary.apk')
         end
       end
 
@@ -68,18 +69,18 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
 
         it 'returns SharedValues::GRADLE_APK_OUTPUT_PATH value' do
           allow(Fastlane::Actions.lane_context).to receive('[]').with(Fastlane::Actions::SharedValues::GRADLE_APK_OUTPUT_PATH).and_return('binary.apk')
-          expect(action.binary_path(:android, params)).to eq('binary.apk')
+          expect(action.get_binary_path(:android, params)).to eq('binary.apk')
         end
 
         it 'attempts to find apk in current director and returns value' do
           allow(Dir).to receive('[]').with('*.apk').and_return(['first-binary.apk', 'last-binary.apk'])
-          expect(action.binary_path(:android, params)).to eq('last-binary.apk')
+          expect(action.get_binary_path(:android, params)).to eq('last-binary.apk')
         end
 
         it 'attempts to find apk in output folder and returns value' do
           allow(Dir).to receive('[]').with('*.apk').and_return([])
           allow(Dir).to receive('[]').with('app/build/outputs/apk/release/app-release.apk').and_return(['first-binary.apk', 'last-binary.apk'])
-          expect(action.binary_path(:android, params)).to eq('last-binary.apk')
+          expect(action.get_binary_path(:android, params)).to eq('last-binary.apk')
         end
       end
 
@@ -88,33 +89,21 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
 
         it 'returns SharedValues::GRADLE_AAB_OUTPUT_PATH value' do
           allow(Fastlane::Actions.lane_context).to receive('[]').with(Fastlane::Actions::SharedValues::GRADLE_AAB_OUTPUT_PATH).and_return('binary.aab')
-          expect(action.binary_path(:android, params)).to eq('binary.aab')
+          expect(action.get_binary_path(:android, params)).to eq('binary.aab')
         end
 
         it 'attempts to find apk in current director and returns value' do
           allow(Dir).to receive('[]').with('*.aab').and_return(['first-binary.aab', 'last-binary.aab'])
-          expect(action.binary_path(:android, params)).to eq('last-binary.aab')
+          expect(action.get_binary_path(:android, params)).to eq('last-binary.aab')
         end
 
         it 'attempts to find apk in output folder and returns value' do
           allow(Dir).to receive('[]').with('*.aab').and_return([])
           allow(Dir).to receive('[]').with('app/build/outputs/bundle/release/app-release.aab').and_return(['first-binary.aab', 'last-binary.aab'])
-          expect(action.binary_path(:android, params)).to eq('last-binary.aab')
+          expect(action.get_binary_path(:android, params)).to eq('last-binary.aab')
         end
       end
     end
-
-    # it 'returns the ipa_path by default when there is no platform' do
-    #   expect(action.binary_path(nil, '/ipa/path', '/apk/path', '/aab/path')).to eq('/ipa/path')
-    # end
-
-    # it 'falls back on the apk_path when there is no platform and no ipa_path' do
-    #   expect(action.binary_path(nil, nil, '/apk/path', '/aab/path')).to eq('/apk/path')
-    # end
-
-    # it 'returns nil when there is no platform and no paths' do
-    #   expect(action.binary_path(nil, nil, nil, nil)).to eq(nil)
-    # end
   end
 
   describe '#xcode_archive_path' do
@@ -178,6 +167,122 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
       params = { googleservice_info_plist_path: '/path/to/plist' }
       expect { action.app_id_from_params(params) }
         .to raise_error(ErrorMessage::MISSING_APP_ID)
+    end
+  end
+
+  describe '#run' do
+    let(:params) do
+      {
+        app: ios_app_id,
+        ipa_path: 'debug.ipa'
+      }
+    end
+
+    before(:each) { allow(File).to receive(:exist?).and_call_original }
+
+    it 'raises error if it cannot find a valid binary path' do
+      allow(File).to receive(:exist?).with('debug.ipa').and_return(false)
+
+      expect do
+        action.run(params.merge(ipa_path: nil))
+      end.to raise_error("Couldn't find binary")
+    end
+
+    it 'raises error if binary does not exist' do
+      allow(File).to receive(:exist?).with('debug.ipa').and_return(false)
+
+      expect do
+        action.run(params)
+      end.to raise_error("Couldn't find binary at path debug.ipa")
+    end
+
+    it 'raises error if contact email is nil' do
+      allow(File).to receive(:exist?).with('debug.ipa').and_return(true)
+      allow_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:get_app).with(ios_app_id, 'BASIC').and_return(App.new({
+        contactEmail: nil
+      }))
+
+      expect do
+        action.run(params)
+      end.to raise_error(ErrorMessage::GET_APP_NO_CONTACT_EMAIL_ERROR)
+    end
+
+    it 'raises error if contact email is blank' do
+      allow(File).to receive(:exist?).with('debug.ipa').and_return(true)
+      allow_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:get_app).with(ios_app_id, 'BASIC').and_return(App.new({
+        contactEmail: ''
+      }))
+
+      expect do
+        action.run(params)
+      end.to raise_error(ErrorMessage::GET_APP_NO_CONTACT_EMAIL_ERROR)
+    end
+
+    describe 'with android app' do
+      let(:params) do
+        {
+          app: android_app_id
+        }
+      end
+
+      describe 'when uploading an AAB' do
+        let(:params) do
+          {
+            app: android_app_id,
+            android_artifact_path: 'debug.aab'
+          }
+        end
+
+        before { allow(File).to receive(:exist?).with('debug.aab').and_return(true) }
+
+        def stub_get_app(params)
+          allow_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:get_app).with(android_app_id, 'FULL').and_return(App.new({
+            projectNumber: project_number,
+            appId: android_app_id,
+            contactEmail: 'user@example.com'
+            }.merge(params)))
+        end
+
+        it 'raises error if play account is not linked' do
+          stub_get_app(aabState: App::AabState::PLAY_ACCOUNT_NOT_LINKED)
+
+          expect do
+            action.run(params)
+          end.to raise_error(ErrorMessage::PLAY_ACCOUNT_NOT_LINKED)
+        end
+
+        it 'raises error if app not published' do
+          stub_get_app(aabState: App::AabState::APP_NOT_PUBLISHED)
+
+          expect do
+            action.run(params)
+          end.to raise_error(ErrorMessage::APP_NOT_PUBLISHED)
+        end
+
+        it 'raises error if no matching app in play account' do
+          stub_get_app(aabState: App::AabState::NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT)
+
+          expect do
+            action.run(params)
+          end.to raise_error(ErrorMessage::NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT)
+        end
+
+        it 'raises error if terms have not been accepted' do
+          stub_get_app(aabState: App::AabState::PLAY_IAS_TERMS_NOT_ACCEPTED)
+
+          expect do
+            action.run(params)
+          end.to raise_error(ErrorMessage::PLAY_IAS_TERMS_NOT_ACCEPTED)
+        end
+
+        it 'raises error if aab state is unrecognized' do
+          stub_get_app(aabState: 'UNKNOWN')
+
+          expect do
+            action.run(params)
+          end.to raise_error(ErrorMessage.aab_upload_error('UNKNOWN'))
+        end
+      end
     end
   end
 end

--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -178,7 +178,10 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
       }
     end
 
-    before(:each) { allow(File).to receive(:exist?).and_call_original }
+    before(:each) do
+      allow(File).to receive(:exist?).and_call_original
+      allow(action).to receive(:fetch_auth_token).and_return('fake-auth-token')
+    end
 
     it 'raises error if it cannot find a valid binary path' do
       allow(File).to receive(:exist?).with('debug.ipa').and_return(false)

--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -184,16 +184,12 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
     end
 
     it 'raises error if it cannot find a valid binary path' do
-      allow(File).to receive(:exist?).with('debug.ipa').and_return(false)
-
       expect do
         action.run(params.merge(ipa_path: nil))
       end.to raise_error("Couldn't find binary")
     end
 
     it 'raises error if binary does not exist' do
-      allow(File).to receive(:exist?).with('debug.ipa').and_return(false)
-
       expect do
         action.run(params)
       end.to raise_error("Couldn't find binary at path debug.ipa")
@@ -222,12 +218,6 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
     end
 
     describe 'with android app' do
-      let(:params) do
-        {
-          app: android_app_id
-        }
-      end
-
       describe 'when uploading an AAB' do
         let(:params) do
           {
@@ -239,7 +229,10 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
         before { allow(File).to receive(:exist?).with('debug.aab').and_return(true) }
 
         def stub_get_app(params)
-          allow_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:get_app).with(android_app_id, 'FULL').and_return(App.new({
+          allow_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient)
+            .to receive(:get_app)
+            .with(android_app_id, 'FULL')
+            .and_return(App.new({
             projectNumber: project_number,
             appId: android_app_id,
             contactEmail: 'user@example.com'

--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -233,9 +233,9 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
             .to receive(:get_app)
             .with(android_app_id, 'FULL')
             .and_return(App.new({
-            projectNumber: project_number,
-            appId: android_app_id,
-            contactEmail: 'user@example.com'
+              projectNumber: project_number,
+              appId: android_app_id,
+              contactEmail: 'user@example.com'
             }.merge(params)))
         end
 

--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -18,23 +18,31 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
 
   describe '#binary_path_from_platform' do
     it 'returns the ipa_path for an iOS app' do
-      expect(action.binary_path_from_platform(:ios, '/ipa/path', '/apk/path')).to eq('/ipa/path')
+      expect(action.binary_path_from_platform(:ios, '/ipa/path', '/apk/path', '/aab/path')).to eq('/ipa/path')
     end
 
     it 'returns the apk_path for an Android app' do
-      expect(action.binary_path_from_platform(:android, '/ipa/path', '/apk/path')).to eq('/apk/path')
+      expect(action.binary_path_from_platform(:android, '/ipa/path', '/apk/path', nil)).to eq('/apk/path')
+    end
+
+    it 'returns the apk_path for an Android app when apk_path and aab_path are provided' do
+      expect(action.binary_path_from_platform(:android, '/ipa/path', '/apk/path', '/aab/path')).to eq('/apk/path')
+    end
+
+    it 'returns the aab_path for an Android app when there is no apk_path' do
+      expect(action.binary_path_from_platform(:android, nil, nil, '/aab/path')).to eq('/aab/path')
     end
 
     it 'returns the ipa_path by default when there is no platform' do
-      expect(action.binary_path_from_platform(nil, '/ipa/path', '/apk/path')).to eq('/ipa/path')
+      expect(action.binary_path_from_platform(nil, '/ipa/path', '/apk/path', '/aab/path')).to eq('/ipa/path')
     end
 
     it 'falls back on the apk_path when there is no platform and no ipa_path' do
-      expect(action.binary_path_from_platform(nil, nil, '/apk/path')).to eq('/apk/path')
+      expect(action.binary_path_from_platform(nil, nil, '/apk/path', '/aab/path')).to eq('/apk/path')
     end
 
     it 'returns nil when there is no platform and no paths' do
-      expect(action.binary_path_from_platform(nil, nil, nil)).to eq(nil)
+      expect(action.binary_path_from_platform(nil, nil, nil, nil)).to eq(nil)
     end
   end
 

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -88,7 +88,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
         .with("invalid_binary_path")
         .and_return(false)
       expect { api_client.get_upload_token("app_id", "invalid_binary_path") }
-        .to raise_error("#{ErrorMessage.binary_not_found('APK')}: invalid_binary_path")
+        .to raise_error("#{ErrorMessage.binary_not_found('AAB/APK')}: invalid_binary_path")
     end
   end
 
@@ -97,7 +97,9 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
       { 'Authorization' => 'Bearer auth_token',
       'X-APP-DISTRO-API-CLIENT-ID' => 'fastlane',
       'X-APP-DISTRO-API-CLIENT-TYPE' =>  "android",
-      'X-APP-DISTRO-API-CLIENT-VERSION' => Fastlane::FirebaseAppDistribution::VERSION }
+      'X-APP-DISTRO-API-CLIENT-VERSION' => Fastlane::FirebaseAppDistribution::VERSION,
+      'X-GOOG-UPLOAD-FILE-NAME' => File.basename(fake_binary_path),
+      'X-GOOG-UPLOAD-PROTOCOL' => 'raw' }
     end
     it 'uploads the binary successfully when the input is valid' do
       stubs.post("/app-binary-uploads?app_id=app_id", fake_binary_contents, upload_headers) do |env|
@@ -117,7 +119,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
         .with("invalid_binary_path", "rb")
         .and_raise(Errno::ENOENT.new("file not found"))
       expect { api_client.upload_binary("app_id", "invalid_binary_path", "android") }
-        .to raise_error("#{ErrorMessage.binary_not_found('APK')}: invalid_binary_path")
+        .to raise_error("#{ErrorMessage.binary_not_found('AAB/APK')}: invalid_binary_path")
     end
   end
 
@@ -234,7 +236,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
         .with("app_id", fake_binary_path, "android")
 
       expect { api_client.upload("app_id", fake_binary_path, "android") }
-        .to raise_error("#{ErrorMessage.upload_binary_error('APK')}: #{upload_status_response_error.message}")
+        .to raise_error("#{ErrorMessage.upload_binary_error('AAB/APK')}: #{upload_status_response_error.message}")
     end
 
     it 'crashes after failing to upload with status unspecified' do
@@ -245,7 +247,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
         .with("app_id", fake_binary_path, "android")
 
       expect { api_client.upload("app_id", fake_binary_path, "android") }
-        .to raise_error(ErrorMessage.upload_binary_error("APK"))
+        .to raise_error(ErrorMessage.upload_binary_error("AAB/APK"))
     end
 
     it 'does not call upload when the intial check returns in progress' do
@@ -390,9 +392,9 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
   end
 
   describe 'Error messaging' do
-    it 'uses "APK" when the platform is android' do
+    it 'uses "AAB/APK" when the platform is android' do
       client = Fastlane::Client::FirebaseAppDistributionApiClient.new("auth_token", :android)
-      expect(client.instance_variable_get(:@binary_type)).to eq('APK')
+      expect(client.instance_variable_get(:@binary_type)).to eq('AAB/APK')
     end
 
     it 'uses "IPA" when the platform is ios' do
@@ -400,9 +402,9 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
       expect(client.instance_variable_get(:@binary_type)).to eq('IPA')
     end
 
-    it 'uses "APK/IPA" when the platform is nil' do
+    it 'uses "AAB/APK/IPA" when the platform is nil' do
       client = Fastlane::Client::FirebaseAppDistributionApiClient.new("auth_token", nil)
-      expect(client.instance_variable_get(:@binary_type)).to eq('IPA/APK')
+      expect(client.instance_variable_get(:@binary_type)).to eq('AAB/APK/IPA')
     end
   end
 end

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -37,58 +37,47 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
     Faraday.default_connection = nil
   end
 
-  describe '#get_upload_token' do
-    it 'returns the upload token after a successfull GET call' do
-      stubs.get("/v1alpha/apps/app_id", headers) do |env|
+  describe '#get_app' do
+    it 'returns an app with appView BASIC' do
+      response = {
+        projectNumber: "project_number",
+        appId: "app_id",
+        contactEmail: "user@example.com"
+      }
+      stubs.get("/v1alpha/apps/app_id?appView=BASIC", headers) do |env|
         [
           200,
           {},
-          {
-            projectNumber: "project_number",
-            appId: "app_id",
-            contactEmail: "Hello@world.com"
-          }
+          response
         ]
       end
-      upload_token = api_client.get_upload_token("app_id", fake_binary_path)
+      app = api_client.get_app("app_id")
       binary_hash = Digest::SHA256.hexdigest(fake_binary_contents)
-      expect(upload_token).to eq(CGI.escape("projects/project_number/apps/app_id/releases/-/binaries/#{binary_hash}"))
+      expect(app.project_number).to eq("project_number")
+      expect(app.app_id).to eq("app_id")
+      expect(app.contact_email).to eq("user@example.com")
     end
 
-    it 'crashes if the app has no contact email' do
-      stubs.get("/v1alpha/apps/app_id", headers) do |env|
+    it 'returns an app with appView FULL' do
+      response = {
+        projectNumber: "project_number",
+        appId: "app_id",
+        contactEmail: "user@example.com",
+        aabState: "ACTIVE"
+      }
+      stubs.get("/v1alpha/apps/app_id?appView=FULL", headers) do |env|
         [
           200,
           {},
-          {
-            projectNumber: "project_number",
-            appId: "app_id",
-            contactEmail: ""
-          }
+          response
         ]
       end
-      expect { api_client.get_upload_token("app_id", fake_binary_path) }
-        .to raise_error(ErrorMessage::GET_APP_NO_CONTACT_EMAIL_ERROR)
-    end
-
-    it 'crashes when given an invalid app_id' do
-      stubs.get("/v1alpha/apps/invalid_app_id", headers) do |env|
-        [
-          404,
-          {},
-          {}
-        ]
-      end
-      expect { api_client.get_upload_token("invalid_app_id", fake_binary_path) }
-        .to raise_error("#{ErrorMessage::INVALID_APP_ID}: invalid_app_id")
-    end
-
-    it 'crashes when given an invalid binary_path' do
-      allow(File).to receive(:exist?)
-        .with("invalid_binary.apk")
-        .and_return(false)
-      expect { api_client.get_upload_token("app_id", "invalid_binary.apk") }
-        .to raise_error("#{ErrorMessage.binary_not_found('APK')}: invalid_binary.apk")
+      app = api_client.get_app("app_id", "FULL")
+      binary_hash = Digest::SHA256.hexdigest(fake_binary_contents)
+      expect(app.project_number).to eq("project_number")
+      expect(app.app_id).to eq("app_id")
+      expect(app.contact_email).to eq("user@example.com")
+      expect(app.aab_state).to eq("ACTIVE")
     end
   end
 
@@ -149,32 +138,30 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
           release: {} }
       )
     end
+    let(:upload_token) do
+      CGI.escape("projects/project_number/apps/app_id/releases/-/binaries/#{Digest::SHA256.hexdigest(fake_binary_contents)}")
+    end
 
     before(:each) do
       # Stub out polling interval for quick specs
       stub_const("Fastlane::Client::FirebaseAppDistributionApiClient::POLLING_INTERVAL_SECONDS", 0)
-
-      # Expect a call to get_upload_token every time
-      expect(api_client).to receive(:get_upload_token)
-        .with("app_id", fake_binary_path)
-        .and_return("upload_token")
     end
 
     it 'skips the upload step if the binary has already been uploaded' do
       # upload should not attempt to upload the binary at all
       expect(api_client).to_not(receive(:upload_binary))
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_success)
 
-      release_id = api_client.upload("app_id", fake_binary_path, "android")
+      release_id = api_client.upload("project_number", "app_id", fake_binary_path, "android")
       expect(release_id).to eq("release_id")
     end
 
     it 'uploads the app binary then returns the release_id' do
       # return an error then a success after being uploaded
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_error, upload_status_response_success)
 
       # upload_binary should only be called once
@@ -182,7 +169,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
         .with("app_id", fake_binary_path, "android")
         .at_most(:once)
 
-      release_id = api_client.upload("app_id", fake_binary_path, "android")
+      release_id = api_client.upload("project_number", "app_id", fake_binary_path, "android")
       expect(release_id).to eq("release_id")
     end
 
@@ -191,16 +178,16 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
       stub_const("Fastlane::Client::FirebaseAppDistributionApiClient::MAX_POLLING_RETRIES", max_polling_retries)
 
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_error)
       expect(api_client).to receive(:upload_binary)
         .with("app_id", fake_binary_path, "android")
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_in_progress)
         .exactly(max_polling_retries).times
 
-      release_id = api_client.upload("app_id", fake_binary_path, "android")
+      release_id = api_client.upload("project_number", "app_id", fake_binary_path, "android")
       expect(release_id).to be_nil
     end
 
@@ -210,56 +197,56 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
 
       # return error the first time
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_error)
       expect(api_client).to receive(:upload_binary)
         .with("app_id", fake_binary_path, "android")
         .at_most(:once)
       # return in_progress for a couple polls
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_in_progress)
         .exactly(2).times
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_success)
 
-      release_id = api_client.upload("app_id", fake_binary_path, "android")
+      release_id = api_client.upload("project_number", "app_id", fake_binary_path, "android")
       expect(release_id).to eq("release_id")
     end
 
     it 'crashes after failing to upload with status error' do
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_error).twice
       expect(api_client).to receive(:upload_binary)
         .with("app_id", fake_binary_path, "android")
 
-      expect { api_client.upload("app_id", fake_binary_path, "android") }
+      expect { api_client.upload("project_number", "app_id", fake_binary_path, "android") }
         .to raise_error("#{ErrorMessage.upload_binary_error('APK')}: #{upload_status_response_error.message}")
     end
 
     it 'crashes after failing to upload with status unspecified' do
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_status_unspecified).twice
       expect(api_client).to receive(:upload_binary)
         .with("app_id", fake_binary_path, "android")
 
-      expect { api_client.upload("app_id", fake_binary_path, "android") }
+      expect { api_client.upload("project_number", "app_id", fake_binary_path, "android") }
         .to raise_error(ErrorMessage.upload_binary_error("APK"))
     end
 
     it 'does not call upload when the intial check returns in progress' do
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_in_progress)
       expect(api_client).to_not(receive(:upload_binary))
       expect(api_client).to receive(:get_upload_status)
-        .with("app_id", "upload_token")
+        .with("app_id", upload_token)
         .and_return(upload_status_response_success)
 
-      release_id = api_client.upload("app_id", fake_binary_path, "android")
+      release_id = api_client.upload("project_number", "app_id", fake_binary_path, "android")
       expect(release_id).to eq("release_id")
     end
   end

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -1,10 +1,10 @@
 describe Fastlane::Client::FirebaseAppDistributionApiClient do
-  let(:fake_binary_path) { "binary_path" }
+  let(:fake_binary_path) { "binary.apk" }
   let(:fake_binary_contents) { "Hello World" }
   let(:fake_binary) { double("Binary") }
   let(:headers) { { 'Authorization' => 'Bearer auth_token' } }
 
-  let(:api_client) { Fastlane::Client::FirebaseAppDistributionApiClient.new("auth_token", :android) }
+  let(:api_client) { Fastlane::Client::FirebaseAppDistributionApiClient.new("auth_token") }
   let(:stubs) { Faraday::Adapter::Test::Stubs.new }
   let(:conn) do
     Faraday.new(url: "https://firebaseappdistribution.googleapis.com") do |b|
@@ -85,10 +85,10 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
 
     it 'crashes when given an invalid binary_path' do
       allow(File).to receive(:exist?)
-        .with("invalid_binary_path")
+        .with("invalid_binary.apk")
         .and_return(false)
-      expect { api_client.get_upload_token("app_id", "invalid_binary_path") }
-        .to raise_error("#{ErrorMessage.binary_not_found('AAB/APK')}: invalid_binary_path")
+      expect { api_client.get_upload_token("app_id", "invalid_binary.apk") }
+        .to raise_error("#{ErrorMessage.binary_not_found('APK')}: invalid_binary.apk")
     end
   end
 
@@ -116,10 +116,10 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
 
     it 'crashes when given an invalid binary_path' do
       expect(File).to receive(:open)
-        .with("invalid_binary_path", "rb")
+        .with("invalid_binary.apk", "rb")
         .and_raise(Errno::ENOENT.new("file not found"))
-      expect { api_client.upload_binary("app_id", "invalid_binary_path", "android") }
-        .to raise_error("#{ErrorMessage.binary_not_found('AAB/APK')}: invalid_binary_path")
+      expect { api_client.upload_binary("app_id", "invalid_binary.apk", "android") }
+        .to raise_error("#{ErrorMessage.binary_not_found('APK')}: invalid_binary.apk")
     end
   end
 
@@ -236,7 +236,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
         .with("app_id", fake_binary_path, "android")
 
       expect { api_client.upload("app_id", fake_binary_path, "android") }
-        .to raise_error("#{ErrorMessage.upload_binary_error('AAB/APK')}: #{upload_status_response_error.message}")
+        .to raise_error("#{ErrorMessage.upload_binary_error('APK')}: #{upload_status_response_error.message}")
     end
 
     it 'crashes after failing to upload with status unspecified' do
@@ -247,7 +247,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
         .with("app_id", fake_binary_path, "android")
 
       expect { api_client.upload("app_id", fake_binary_path, "android") }
-        .to raise_error(ErrorMessage.upload_binary_error("AAB/APK"))
+        .to raise_error(ErrorMessage.upload_binary_error("APK"))
     end
 
     it 'does not call upload when the intial check returns in progress' do
@@ -388,23 +388,6 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
       end
       expect { api_client.enable_access("app_id", "release_id", emails, group_ids) }
         .to raise_error("#{ErrorMessage::INVALID_TESTERS} \nEmails: #{emails} \nGroups: #{group_ids}")
-    end
-  end
-
-  describe 'Error messaging' do
-    it 'uses "AAB/APK" when the platform is android' do
-      client = Fastlane::Client::FirebaseAppDistributionApiClient.new("auth_token", :android)
-      expect(client.instance_variable_get(:@binary_type)).to eq('AAB/APK')
-    end
-
-    it 'uses "IPA" when the platform is ios' do
-      client = Fastlane::Client::FirebaseAppDistributionApiClient.new("auth_token", :ios)
-      expect(client.instance_variable_get(:@binary_type)).to eq('IPA')
-    end
-
-    it 'uses "AAB/APK/IPA" when the platform is nil' do
-      client = Fastlane::Client::FirebaseAppDistributionApiClient.new("auth_token", nil)
-      expect(client.instance_variable_get(:@binary_type)).to eq('AAB/APK/IPA')
     end
   end
 end

--- a/spec/firebase_app_distribution_helper_spec.rb
+++ b/spec/firebase_app_distribution_helper_spec.rb
@@ -92,4 +92,24 @@ describe Fastlane::Helper::FirebaseAppDistributionHelper do
       expect(helper.get_ios_app_id_from_archive_plist("path", "GoogleService-Info.plist")).to eq("identifier")
     end
   end
+
+  describe '#binary_type_from_path' do
+    it 'returns IPA' do
+      expect(helper.binary_type_from_path('debug.ipa')).to eq(Fastlane::Helper::FirebaseAppDistributionHelper::IPA)
+    end
+
+    it 'returns APK' do
+      expect(helper.binary_type_from_path('debug.apk')).to eq(Fastlane::Helper::FirebaseAppDistributionHelper::APK)
+    end
+
+    it 'returns AAB' do
+      expect(helper.binary_type_from_path('debug.aab')).to eq(Fastlane::Helper::FirebaseAppDistributionHelper::AAB)
+    end
+
+    it 'raises error if file extension is unsupported' do
+      expect do
+        helper.binary_type_from_path('debug.invalid')
+      end.to raise_error("Unsupported distribution file format, should be .ipa, .apk or .aab")
+    end
+  end
 end

--- a/spec/firebase_app_distribution_helper_spec.rb
+++ b/spec/firebase_app_distribution_helper_spec.rb
@@ -95,15 +95,15 @@ describe Fastlane::Helper::FirebaseAppDistributionHelper do
 
   describe '#binary_type_from_path' do
     it 'returns IPA' do
-      expect(helper.binary_type_from_path('debug.ipa')).to eq(Fastlane::Helper::FirebaseAppDistributionHelper::IPA)
+      expect(helper.binary_type_from_path('debug.ipa')).to eq(:IPA)
     end
 
     it 'returns APK' do
-      expect(helper.binary_type_from_path('debug.apk')).to eq(Fastlane::Helper::FirebaseAppDistributionHelper::APK)
+      expect(helper.binary_type_from_path('debug.apk')).to eq(:APK)
     end
 
     it 'returns AAB' do
-      expect(helper.binary_type_from_path('debug.aab')).to eq(Fastlane::Helper::FirebaseAppDistributionHelper::AAB)
+      expect(helper.binary_type_from_path('debug.aab')).to eq(:AAB)
     end
 
     it 'raises error if file extension is unsupported' do


### PR DESCRIPTION
This PR refactors the code and makes the following changes:
- Adds an `android_artifact_path` and an `android_artifact_type` parameter. 
- Adds error handling for AAB's
- Adds tests for the run method in the action class

The process to determine where to get the binary is similar to how the gradle plugin works:
- If it's an android app and `android_artifact_path` or `apk_path` (which I deprecated) is set, it uses those values.
- If they aren't set and `android_artifact_type` is set to `AAB` it attempts to infer a path to the `AAB`.
- Otherwise it attempts to infer a path to the `APK`.

