### PR TITLE
Add new action to download tester UDIDs

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
@@ -47,7 +47,7 @@ module Fastlane
 
       # supports markdown.
       def self.details
-        "Export your testers' device names and identifiers in a CSV file, so you can add them your app's provisioning profile. This file can be imported into your Apple developer account using the Register Multiple Devices option. See the [App Distribution docs](https://firebase.google.com/docs/app-distribution/ios/distribute-console#register-tester-devices) for more info."
+        "Export your testers' device identifiers in a CSV file, so you can add them your provisioning profile. This file can be imported into your Apple developer account using the Register Multiple Devices option. See the [App Distribution docs](https://firebase.google.com/docs/app-distribution/ios/distribute-console#register-tester-devices) for more info."
       end
 
       def self.available_options
@@ -95,4 +95,3 @@ module Fastlane
     end
   end
 end
-

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
@@ -1,0 +1,93 @@
+require 'fastlane/action'
+require 'open3'
+require 'shellwords'
+require 'googleauth'
+require_relative '../helper/firebase_app_distribution_helper'
+require_relative '../helper/firebase_app_distribution_error_message'
+require_relative '../client/firebase_app_distribution_api_client'
+require_relative '../helper/firebase_app_distribution_auth_client'
+
+module Fastlane
+  module Actions
+    class FirebaseAppDistributionGetUdidsAction < Action
+      extend Auth::FirebaseAppDistributionAuthClient
+      extend Helper::FirebaseAppDistributionHelper
+
+      def self.run(params)
+        auth_token = fetch_auth_token(params[:service_credentials_file], params[:firebase_cli_token])
+        fad_api_client = Client::FirebaseAppDistributionApiClient.new(auth_token, params[:debug])
+
+        app_id = params[:app]
+        udids = fad_api_client.get_udids(app_id)
+        write_udids_to_file(udids, params[:output_file])
+        UI.success("🎉 App Distribution tester UDIDs written to: #{params[:output_file]}")
+      end
+
+      def self.write_udids_to_file(udids, output_file)
+        File.open(output_file, 'w') do |f|
+          f.write("Device ID\tDevice Name\tDevice Platform\n")
+          udids.each do |tester_udid|
+            f.write("#{tester_udid[:udid]}\t#{tester_udid[:name]}\t#{tester_udid[:platform]}\n")
+          end
+        end
+      end
+
+      def self.description
+        "Download the UDIDs of your Firebase App Distribution testers"
+      end
+
+      def self.authors
+        ["Lee Kellogg"]
+      end
+
+      # supports markdown.
+      def self.details
+        "Export your testers' device names and identifiers in a CSV file, so you can add them your app's provisioning profile. This file can be imported into your Apple developer account using the Register Multiple Devices option. See the [App Distribution docs](https://firebase.google.com/docs/app-distribution/ios/distribute-console#register-tester-devices) for more info."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :app,
+                                       env_name: "FIREBASEAPPDISTRO_APP",
+                                       description: "Your app's Firebase App ID. You can find the App ID in the Firebase console, on the General Settings page",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :output_file,
+                                       env_name: "FIREBASEAPPDISTRO_OUTPUT_FILE",
+                                       description: "The path to the file where the tester UDIDs will be written",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :firebase_cli_token,
+                                       description: "Auth token for firebase cli",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :service_credentials_file,
+                                       description: "Path to Google service account json",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :debug,
+                                       description: "Print verbose debug output",
+                                       optional: true,
+                                       default_value: false,
+                                       is_string: false)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        [:ios].include?(platform)
+      end
+
+      def self.example_code
+        [
+          <<-CODE
+            firebase_app_distribution_get_udids(
+              app: "1:1234567890:ios:0a1b2c3d4e5f67890",
+              output_file: "tester_udids.txt",
+            )
+          CODE
+        ]
+      end
+    end
+  end
+end
+

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
@@ -19,8 +19,13 @@ module Fastlane
 
         app_id = params[:app]
         udids = fad_api_client.get_udids(app_id)
-        write_udids_to_file(udids, params[:output_file])
-        UI.success("🎉 App Distribution tester UDIDs written to: #{params[:output_file]}")
+
+        if udids.empty?
+          UI.important("App Distribution fetched 0 tester UDIDs. Nothing written to output file.")
+        else
+          write_udids_to_file(udids, params[:output_file])
+          UI.success("🎉 App Distribution tester UDIDs written to: #{params[:output_file]}")
+        end
       end
 
       def self.write_udids_to_file(udids, output_file)

--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -180,6 +180,23 @@ module Fastlane
         return UploadStatusResponse.new(response.body)
       end
 
+      # Get tester UDIDs
+      #
+      # args
+      #   app_id - Firebase App ID
+      #
+      # Returns a list of hashes containing tester device info
+      def get_udids(app_id)
+        begin
+          response = connection.get(get_udids_url(app_id)) do |request|
+            request.headers[AUTHORIZATION] = "Bearer " + @auth_token
+          end
+        rescue Faraday::ResourceNotFound
+          UI.user_error!("#{ErrorMessage::INVALID_APP_ID}: #{app_id}")
+        end
+        response.body[:testerUdids]
+      end
+
       private
 
       def v1_apps_url(app_id)
@@ -200,6 +217,10 @@ module Fastlane
 
       def upload_status_url(app_id, app_token)
         "#{v1_apps_url(app_id)}/upload_status/#{app_token}"
+      end
+
+      def get_udids_url(app_id)
+        "#{v1_apps_url(app_id)}/testers:getTesterUdids"
       end
 
       def get_upload_token(project_number, app_id, binary_path)

--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -194,7 +194,7 @@ module Fastlane
         rescue Faraday::ResourceNotFound
           UI.user_error!("#{ErrorMessage::INVALID_APP_ID}: #{app_id}")
         end
-        response.body[:testerUdids]
+        response.body[:testerUdids] || []
       end
 
       private

--- a/lib/fastlane/plugin/firebase_app_distribution/version.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FirebaseAppDistribution
-    VERSION = "0.2.6.pre.1"
+    VERSION = "0.2.7.pre.1"
   end
 end

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -364,6 +364,18 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
       result = api_client.get_udids("app_id")
       expect(result).to eq(udids)
     end
+
+    it 'returns an empty list UDIDs when there are no udids' do
+      stubs.get("/v1alpha/apps/app_id/testers:getTesterUdids", headers) do |env|
+        [
+          200,
+          {},
+          {},
+        ]
+      end
+      result = api_client.get_udids("app_id")
+      expect(result).to eq([])
+    end
   end
 
   describe '#enable_access' do

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -345,6 +345,27 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
     end
   end
 
+  describe '#get_udids' do
+    let(:udids) {
+      [
+        { udid: 'device-udid-1', name: 'device-name-1', platform: 'ios' },
+        { udid: 'device-udid-1', name: 'device-name-1', platform: 'ios' },
+      ]
+    }
+
+    it 'returns the list of UDIDs when the get call is successfull' do
+      stubs.get("/v1alpha/apps/app_id/testers:getTesterUdids", headers) do |env|
+        [
+          200,
+          {},
+          { testerUdids: udids },
+        ]
+      end
+      result = api_client.get_udids("app_id")
+      expect(result).to eq(udids)
+    end
+  end
+
   describe '#enable_access' do
     it 'posts successfully when tester emails and groupIds are defined' do
       payload = { emails: ["testers"], groupIds: ["groups"] }

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -346,19 +346,19 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
   end
 
   describe '#get_udids' do
-    let(:udids) {
+    let(:udids) do
       [
         { udid: 'device-udid-1', name: 'device-name-1', platform: 'ios' },
-        { udid: 'device-udid-1', name: 'device-name-1', platform: 'ios' },
+        { udid: 'device-udid-1', name: 'device-name-1', platform: 'ios' }
       ]
-    }
+    end
 
     it 'returns the list of UDIDs when the get call is successfull' do
       stubs.get("/v1alpha/apps/app_id/testers:getTesterUdids", headers) do |env|
         [
           200,
           {},
-          { testerUdids: udids },
+          { testerUdids: udids }
         ]
       end
       result = api_client.get_udids("app_id")
@@ -370,7 +370,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
         [
           200,
           {},
-          {},
+          {}
         ]
       end
       result = api_client.get_udids("app_id")

--- a/spec/firebase_app_distribution_get_udids_spec.rb
+++ b/spec/firebase_app_distribution_get_udids_spec.rb
@@ -3,7 +3,7 @@ require 'fastlane/action'
 describe Fastlane::Actions::FirebaseAppDistributionGetUdidsAction do
   let(:action) { Fastlane::Actions::FirebaseAppDistributionGetUdidsAction }
   let(:app_id) { '1:1234567890:android:321abc456def7890' }
-  let(:mock_file) { StringIO.new() }
+  let(:mock_file) { StringIO.new }
   let(:output_file_path) { '/path/to/output/file.txt' }
 
   describe '#run' do
@@ -13,35 +13,33 @@ describe Fastlane::Actions::FirebaseAppDistributionGetUdidsAction do
         allow_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient)
           .to receive(:get_udids)
           .with(app_id)
-          .and_return([
-            {
-              udid: 'device-udid-1',
-              name: 'device-name-1',
-              platform: 'ios',
-            },
-            {
-              udid: 'device-udid-2',
-              name: 'device-name-2',
-              platform: 'ios',
-            },
-          ])
+          .and_return(
+            [
+              {
+                udid: 'device-udid-1',
+                name: 'device-name-1',
+                platform: 'ios'
+              },
+              {
+                udid: 'device-udid-2',
+                name: 'device-name-2',
+                platform: 'ios'
+              }
+            ]
+          )
       end
 
       let(:params) do
         {
           app: app_id,
-          output_file: output_file_path,
+          output_file: output_file_path
         }
       end
 
       it 'writes UDIDs to file' do
         expect(File).to receive(:open).with(output_file_path, 'w').and_yield(mock_file)
         action.run(params)
-        expect(mock_file.string).to eq(
-          "Device ID\tDevice Name\tDevice Platform\n" +
-          "device-udid-1\tdevice-name-1\tios\n" +
-          "device-udid-2\tdevice-name-2\tios\n"
-        )
+        expect(mock_file.string).to eq("Device ID\tDevice Name\tDevice Platform\ndevice-udid-1\tdevice-name-1\tios\ndevice-udid-2\tdevice-name-2\tios\n")
       end
     end
   end
@@ -58,14 +56,14 @@ describe Fastlane::Actions::FirebaseAppDistributionGetUdidsAction do
     let(:params) do
       {
         app: app_id,
-        output_file: output_file_path,
+        output_file: output_file_path
       }
     end
 
     it 'does not write to file' do
       allow(File).to receive(:open).and_yield(mock_file)
       action.run(params)
-      expect(File).not_to have_received(:open)
+      expect(File).not_to(have_received(:open))
     end
   end
 end

--- a/spec/firebase_app_distribution_get_udids_spec.rb
+++ b/spec/firebase_app_distribution_get_udids_spec.rb
@@ -1,0 +1,46 @@
+require 'fastlane/action'
+
+describe Fastlane::Actions::FirebaseAppDistributionGetUdidsAction do
+  let(:action) { Fastlane::Actions::FirebaseAppDistributionGetUdidsAction }
+  let(:app_id) { '1:1234567890:android:321abc456def7890' }
+  let(:mock_file) { StringIO.new() }
+  let(:output_file_path) { '/path/to/output/file.txt' }
+
+  describe '#run' do
+    before(:each) do
+      allow(action).to receive(:fetch_auth_token).and_return('fake-auth-token')
+      allow_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient)
+        .to receive(:get_udids)
+        .with(app_id)
+        .and_return([
+          {
+            udid: 'device-udid-1',
+            name: 'device-name-1',
+            platform: 'ios',
+          },
+          {
+            udid: 'device-udid-2',
+            name: 'device-name-2',
+            platform: 'ios',
+          },
+        ])
+    end
+
+    let(:params) do
+      {
+        app: app_id,
+        output_file: output_file_path,
+      }
+    end
+
+    it 'writes UDIDs to file' do
+      expect(File).to receive(:open).with(output_file_path, 'w').and_yield(mock_file)
+      action.run(params)
+      expect(mock_file.string).to eq(
+        "Device ID\tDevice Name\tDevice Platform\n" + 
+        "device-udid-1\tdevice-name-1\tios\n" +
+        "device-udid-2\tdevice-name-2\tios\n"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Example:

```
    firebase_app_distribution_get_udids(
        app: "1:1234567890:ios:1234567890abcdef",
        firebase_cli_token: "<token value>",
        output_file: "/Users/myusername/tester_udids.txt",
    )
```

Output (with debug enabled):

```
[09:23:15]: Driving the lane 'download_udids' 🚀
[09:23:15]: -------------------------------------------------
[09:23:15]: --- Step: firebase_app_distribution_get_udids ---
[09:23:15]: -------------------------------------------------
[09:23:15]: Authenticating with --firebase_cli_token parameter
[09:23:15]: 🔐 Authenticated successfully.
D, [2021-03-23T09:23:15.680917 #87440] DEBUG -- request: GET https://firebaseappdistribution.googleapis.com/v1alpha/apps/1:1234567890:ios:1234567890abcdef/testers:getTesterUdids
D, [2021-03-23T09:23:16.117578 #87440] DEBUG -- response: Status 200
D, [2021-03-23T09:23:16.117796 #87440] DEBUG -- response: {
  "testerUdids": [
    {
      "udid": "<udid here>",
      "name": "<device name here>",
      "platform": "ios"
    }
  ]
}

[09:23:16]: 🎉 App Distribution tester UDIDs written to: /Users/myusername/tester_udids.txt
```