### PR TITLE
Exit with a non-zero status code if upload does not finish

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -34,11 +34,7 @@ module Fastlane
         app_view = binary_type == :AAB ? 'FULL' : 'BASIC'
         app = fad_api_client.get_app(app_id, app_view)
         validate_app!(app, binary_type)
-
         release_id = fad_api_client.upload(app.project_number, app_id, binary_path, platform.to_s)
-        if release_id.nil?
-          return
-        end
 
         if binary_type == :AAB && app.aab_certificate.empty?
           updated_app = fad_api_client.get_app(app_id)

--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -127,10 +127,10 @@ module Fastlane
       #   app_id - Firebase app ID
       #   binary_path - Absolute path to your app's aab/apk/ipa file
       #
-      # Returns the release_id on a successful release, otherwise returns nil.
+      # Returns the release_id of the uploaded release.
       #
-      # Throws a UI error if the number of polling retries exceeds MAX_POLLING_RETRIES
-      # Crashes if not able to upload the binary
+      # Crashes if the number of polling retries exceeds MAX_POLLING_RETRIES or if the binary cannot
+      # be uploaded.
       def upload(project_number, app_id, binary_path, platform)
         binary_type = binary_type_from_path(binary_path)
 

--- a/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/client/firebase_app_distribution_api_client.rb
@@ -159,8 +159,7 @@ module Fastlane
             end
           end
           unless upload_status_response.success?
-            UI.error("It took longer than expected to process your #{binary_type}, please try again.")
-            return nil
+            UI.crash!("It took longer than expected to process your #{binary_type}, please try again.")
           end
         end
         upload_status_response.release_id

--- a/spec/firebase_app_distribution_api_client_spec.rb
+++ b/spec/firebase_app_distribution_api_client_spec.rb
@@ -203,7 +203,7 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
       expect(release_id).to eq("release_id")
     end
 
-    it 'returns nil after polling MAX_POLLING_RETRIES times' do
+    it 'raises an error after polling MAX_POLLING_RETRIES times' do
       max_polling_retries = 2
       stub_const("Fastlane::Client::FirebaseAppDistributionApiClient::MAX_POLLING_RETRIES", max_polling_retries)
 
@@ -217,8 +217,9 @@ describe Fastlane::Client::FirebaseAppDistributionApiClient do
         .and_return(upload_status_response_in_progress)
         .exactly(max_polling_retries).times
 
-      release_id = api_client.upload("project_number", "app_id", fake_binary_path, "android")
-      expect(release_id).to be_nil
+      expect do
+        api_client.upload("project_number", "app_id", fake_binary_path, "android")
+      end.to raise_error
     end
 
     it 'uploads the app binary once then polls until success' do


### PR DESCRIPTION
If after 2 minutes the status shows the binary is still being processed, then exit with an error. Otherwise we are hiding the fact that that distribution may not be uploaded successfully.