### PR TITLE
Print details of service account auth errors

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -27,7 +27,9 @@ module Fastlane
         UI.user_error!("Couldn't find binary at path #{binary_path}") unless File.exist?(binary_path)
         binary_type = binary_type_from_path(binary_path)
 
-        auth_token = fetch_auth_token(params[:service_credentials_file], params[:firebase_cli_token])
+        auth_token = fetch_auth_token(
+          params[:service_credentials_file], params[:firebase_cli_token], params[:debug]
+        )
         fad_api_client = Client::FirebaseAppDistributionApiClient.new(auth_token, params[:debug])
 
         # If binary is an AAB, get the AAB info for this app, which includes the integration state and certificate data

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
@@ -83,8 +83,11 @@ module Fastlane
         service_account_credentials.fetch_access_token!["access_token"]
       rescue Errno::ENOENT
         UI.user_error!("#{ErrorMessage::SERVICE_CREDENTIALS_NOT_FOUND}: #{google_service_path}")
-      rescue Signet::AuthorizationError
-        UI.user_error!("#{ErrorMessage::SERVICE_CREDENTIALS_ERROR}: #{google_service_path}")
+      rescue Signet::AuthorizationError => error
+        UI.user_error!(
+          "#{ErrorMessage::SERVICE_CREDENTIALS_ERROR}: #{google_service_path}" \
+          "\n\nDetails:\n#{error.message}\nResponse status: #{error.response.status}"
+        )
       end
     end
   end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
@@ -71,8 +71,11 @@ module Fastlane
         )
         client.fetch_access_token!
         client.access_token
-      rescue Signet::AuthorizationError
-        UI.user_error!(ErrorMessage::REFRESH_TOKEN_ERROR)
+      rescue Signet::AuthorizationError => error
+        UI.user_error!(
+          "#{ErrorMessage::REFRESH_TOKEN_ERROR}" \
+          "\n\nDetails:\n#{error.message}\nResponse status: #{error.response.status}"
+        )
       end
 
       def service_account(google_service_path)

--- a/spec/firebase_app_distribution_auth_client_spec.rb
+++ b/spec/firebase_app_distribution_auth_client_spec.rb
@@ -107,9 +107,9 @@ describe Fastlane::Auth::FirebaseAppDistributionAuthClient do
 
         it 'crashes if given an invalid firebase token' do
           expect(firebase_auth).to receive(:new)
-            .and_raise(Signet::AuthorizationError.new("error"))
+            .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
           expect { auth_client.fetch_auth_token(empty_val, "invalid_refresh_token") }
-            .to raise_error(ErrorMessage::REFRESH_TOKEN_ERROR)
+            .to raise_error(/could not generate credentials.*error_message.*400/m)
         end
 
         it 'crashes if the firebase tools json has no tokens field' do

--- a/spec/firebase_app_distribution_auth_client_spec.rb
+++ b/spec/firebase_app_distribution_auth_client_spec.rb
@@ -101,15 +101,15 @@ describe Fastlane::Auth::FirebaseAppDistributionAuthClient do
         it 'crashes if the service credentials are invalid' do
           expect(fake_service_creds).to receive(:fetch_access_token!)
             .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
-          expect { auth_client.fetch_auth_token("invalid_service_path", empty_val) }
-            .to raise_error(/invalid_service_path.*error_message.*400/m)
+          expect { auth_client.fetch_auth_token("invalid_service_path", empty_val, true) }
+            .to raise_error("#{ErrorMessage::SERVICE_CREDENTIALS_ERROR}: invalid_service_path")
         end
 
         it 'crashes if given an invalid firebase token' do
           expect(firebase_auth).to receive(:new)
             .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
-          expect { auth_client.fetch_auth_token(empty_val, "invalid_refresh_token") }
-            .to raise_error(/could not generate credentials.*error_message.*400/m)
+          expect { auth_client.fetch_auth_token(empty_val, "invalid_refresh_token", true) }
+            .to raise_error(ErrorMessage::REFRESH_TOKEN_ERROR)
         end
 
         it 'crashes if the firebase tools json has no tokens field' do

--- a/spec/firebase_app_distribution_auth_client_spec.rb
+++ b/spec/firebase_app_distribution_auth_client_spec.rb
@@ -10,6 +10,7 @@ describe Fastlane::Auth::FirebaseAppDistributionAuthClient do
   let(:fake_service_creds) { double("service_account_creds") }
   let(:fake_oauth_client) { double("oauth_client") }
   let(:payload) { { "access_token" => "service_fake_auth_token" } }
+  let(:fake_error_response) { double("error_response") }
 
   before(:each) do
     allow(firebase_auth).to receive(:new)
@@ -30,6 +31,8 @@ describe Fastlane::Auth::FirebaseAppDistributionAuthClient do
       .and_return(fake_binary_contents)
     allow(fake_binary_contents).to receive(:key)
       .and_return("fake_service_key")
+
+    allow(fake_error_response).to receive(:status).and_return(400)
   end
 
   describe '#fetch_auth_token' do
@@ -97,9 +100,9 @@ describe Fastlane::Auth::FirebaseAppDistributionAuthClient do
 
         it 'crashes if the service credentials are invalid' do
           expect(fake_service_creds).to receive(:fetch_access_token!)
-            .and_raise(Signet::AuthorizationError.new("error"))
+            .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
           expect { auth_client.fetch_auth_token("invalid_service_path", empty_val) }
-            .to raise_error("#{ErrorMessage::SERVICE_CREDENTIALS_ERROR}: invalid_service_path")
+            .to raise_error(/invalid_service_path.*error_message.*400/m)
         end
 
         it 'crashes if given an invalid firebase token' do


### PR DESCRIPTION
This will help troubleshoot in cases like https://github.com/fastlane/fastlane-plugin-firebase_app_distribution/issues/215.

Before:
```
[!] App Distribution could not generate credentials from the service credentials file specified. Service Account Path: <path>
```

After:
```
[!] App Distribution could not generate credentials from the service credentials file specified. Service Account Path: <path>

Details:
Authorization failed.  Server message:
{"error":"invalid_grant","error_description":"Invalid grant: account not found"}
Response status: 400
```