### PR TITLE
Add is_supported? to add/remove tester actions

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_add_testers_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_add_testers_action.rb
@@ -76,6 +76,10 @@ module Fastlane
                                        is_string: false)
         ]
       end
+
+      def self.is_supported?(platform)
+        true
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_remove_testers_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_remove_testers_action.rb
@@ -74,6 +74,10 @@ module Fastlane
 
         ]
       end
+
+      def self.is_supported?(platform)
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
Currently fails with the following error:

```
 [!] Implementing `is_supported?` for all actions is mandatory. Please update Fastlane::Actions::FirebaseAppDistributionAddTestersAction (FastlaneCore::Interface::FastlaneCrash)
```