### PR TITLE
Rename project param to project_number

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_add_testers_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_add_testers_action.rb
@@ -24,7 +24,7 @@ module Fastlane
           UI.user_error!("A maximum of 1000 testers can be added at a time.")
         end
 
-        fad_api_client.add_testers(params[:project], emails)
+        fad_api_client.add_testers(params[:project_number], emails)
 
         # The add_testers response lists all the testers from the request
         # regardless of whether or not they were created or if they already
@@ -47,7 +47,7 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :project,
+          FastlaneCore::ConfigItem.new(key: :project_number,
                                       env_name: "FIREBASEAPPDISTRO_PROJECT_NUMBER",
                                       description: "Your Firebase project number. You can find the project number in the Firebase console, on the General Settings page",
                                       type: Integer),

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_remove_testers_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_remove_testers_action.rb
@@ -24,7 +24,7 @@ module Fastlane
           UI.user_error!("A maximum of 1000 testers can be removed at a time.")
         end
 
-        count = fad_api_client.remove_testers(params[:project], emails)
+        count = fad_api_client.remove_testers(params[:project_number], emails)
 
         UI.success("✅ #{count} tester(s) removed successfully.")
       end
@@ -44,7 +44,7 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :project,
+          FastlaneCore::ConfigItem.new(key: :project_number,
                                       env_name: "FIREBASEAPPDISTRO_PROJECT_NUMBER",
                                       description: "Your Firebase project number. You can find the project number in the Firebase console, on the General Settings page",
                                       type: Integer),

--- a/spec/firebase_app_distribution_add_testers_action_spec.rb
+++ b/spec/firebase_app_distribution_add_testers_action_spec.rb
@@ -20,16 +20,16 @@ describe Fastlane::Actions::FirebaseAppDistributionAddTestersAction do
     end
 
     it 'succeeds and makes call with value from emails param' do
-      project = 1
+      project_number = 1
       emails = '1@e.mail,2@e.mail'
       path = 'path/to/file'
-      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:add_testers).with(project, emails.split(','))
+      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:add_testers).with(project_number, emails.split(','))
 
-      action.run({ project: project, emails: emails, file: path })
+      action.run({ project_number: project_number, emails: emails, file: path })
     end
 
     it 'succeeds and makes call with value from file' do
-      project = 1
+      project_number = 1
       emails = '1@e.mail,2@e.mail'
       path = 'path/to/file'
       fake_file = double('file')
@@ -37,9 +37,9 @@ describe Fastlane::Actions::FirebaseAppDistributionAddTestersAction do
         .with(path)
         .and_return(fake_file)
       allow(fake_file).to receive(:read).and_return(emails)
-      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:add_testers).with(project, emails.split(','))
+      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:add_testers).with(project_number, emails.split(','))
 
-      action.run({ project: project, file: path })
+      action.run({ project_number: project_number, file: path })
     end
   end
 end

--- a/spec/firebase_app_distribution_remove_testers_action_spec.rb
+++ b/spec/firebase_app_distribution_remove_testers_action_spec.rb
@@ -21,19 +21,19 @@ describe Fastlane::Actions::FirebaseAppDistributionRemoveTestersAction do
     end
 
     it 'succeeds and makes call with value from emails param' do
-      project = 1
+      project_number = 1
       emails = '1@e.mail,2@e.mail'
       path = 'path/to/file'
       count = 1
-      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:remove_testers).with(project, emails.split(',')).and_return(count)
+      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:remove_testers).with(project_number, emails.split(',')).and_return(count)
       allow(FastlaneCore::UI).to receive(:success)
       expect(FastlaneCore::UI).to receive(:success).with("✅ #{count} tester(s) removed successfully.")
 
-      action.run({ project: project, emails: emails, file: path })
+      action.run({ project_number: project_number, emails: emails, file: path })
     end
 
     it 'succeeds and makes call with value from file' do
-      project = 1
+      project_number = 1
       emails = '1@e.mail,2@e.mail'
       path = 'path/to/file'
       count = 1
@@ -42,11 +42,11 @@ describe Fastlane::Actions::FirebaseAppDistributionRemoveTestersAction do
         .with(path)
         .and_return(fake_file)
       allow(fake_file).to receive(:read).and_return(emails)
-      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:remove_testers).with(project, emails.split(',')).and_return(count)
+      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:remove_testers).with(project_number, emails.split(',')).and_return(count)
       allow(FastlaneCore::UI).to receive(:success)
       expect(FastlaneCore::UI).to receive(:success).with("✅ #{count} tester(s) removed successfully.")
 
-      action.run({ project: project, file: path })
+      action.run({ project_number: project_number, file: path })
     end
   end
 end


### PR DESCRIPTION
Prefer `project_number` to `project` to ensure developers don't use project ID