### PR TITLE
Handle whitespaces and empty email arrays

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_add_testers_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_add_testers_action.rb
@@ -18,7 +18,9 @@ module Fastlane
           UI.user_error!("Must specify `emails` or `file`.")
         end
 
-        emails = get_value_from_value_or_file(params[:emails], params[:file]).split(',')
+        emails = string_to_array(get_value_from_value_or_file(params[:emails], params[:file]))
+
+        UI.user_error!("Must pass at least one email") if blank?(emails)
 
         if emails.count > 1000
           UI.user_error!("A maximum of 1000 testers can be added at a time.")

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_remove_testers_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_remove_testers_action.rb
@@ -18,7 +18,9 @@ module Fastlane
           UI.user_error!("Must specify `emails` or `file`.")
         end
 
-        emails = get_value_from_value_or_file(params[:emails], params[:file]).split(',')
+        emails = string_to_array(get_value_from_value_or_file(params[:emails], params[:file]))
+
+        UI.user_error!("Must pass at least one email") if blank?(emails)
 
         if emails.count > 1000
           UI.user_error!("A maximum of 1000 testers can be removed at a time.")

--- a/spec/firebase_app_distribution_add_testers_action_spec.rb
+++ b/spec/firebase_app_distribution_add_testers_action_spec.rb
@@ -12,6 +12,11 @@ describe Fastlane::Actions::FirebaseAppDistributionAddTestersAction do
         .to raise_error("Must specify `emails` or `file`.")
     end
 
+    it 'raises an error if there are no emails' do
+      expect { action.run({ project_number: 1, emails: " " }) }
+        .to raise_error("Must pass at least one email")
+    end
+
     it 'raises an error if there are > 1000 emails' do
       emails = (1..1001).map { |i| "#{i}@e.mail" }.join(',')
 

--- a/spec/firebase_app_distribution_remove_testers_action_spec.rb
+++ b/spec/firebase_app_distribution_remove_testers_action_spec.rb
@@ -20,6 +20,11 @@ describe Fastlane::Actions::FirebaseAppDistributionRemoveTestersAction do
         .to raise_error("A maximum of 1000 testers can be removed at a time.")
     end
 
+    it 'raises an error if there are no emails' do
+      expect { action.run({ project_number: 1, emails: " " }) }
+        .to raise_error("Must pass at least one email")
+    end
+
     it 'succeeds and makes call with value from emails param' do
       project_number = 1
       emails = '1@e.mail,2@e.mail'


### PR DESCRIPTION
Prefer `string_to_array` instead of `split` since it handles whitespaces and handle case where `nil` or `[]` is returned from `string_to_array`