### PR TITLE
Bump version to 0.3.2.pre.1

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/version.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FirebaseAppDistribution
-    VERSION = "0.3.1"
+    VERSION = "0.3.2.pre.1"
   end
 end


### PR DESCRIPTION
Includes new `firebase_app_distribution_get_latest_release` action.