### PR TITLE
Update code examples

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -253,7 +253,7 @@ module Fastlane
         [
           <<-CODE
             firebase_app_distribution(
-              app: "1:1234567890:ios:0a1b2c3d4e5f67890",
+              app: "<your Firebase app ID>",
               testers: "snatchev@google.com, rebeccahe@google.com"
             )
           CODE

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_latest_release.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_latest_release.rb
@@ -88,9 +88,9 @@ module Fastlane
 
       def self.example_code
         [
-          'release = firebase_app_distribution_get_latest_release(app: "1:1234567890:ios:0a1b2c3d4e5f67890")',
+          'release = firebase_app_distribution_get_latest_release(app: "<your Firebase app ID>")',
           'increment_build_number({
-            build_number: firebase_app_distribution_get_latest_release(app: "1:1234567890:ios:0a1b2c3d4e5f67890")[:buildVersion].to_i + 1
+            build_number: firebase_app_distribution_get_latest_release(app: "<your Firebase app ID>")[:buildVersion].to_i + 1
           })'
         ]
       end

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
@@ -86,7 +86,7 @@ module Fastlane
         [
           <<-CODE
             firebase_app_distribution_get_udids(
-              app: "1:1234567890:ios:0a1b2c3d4e5f67890",
+              app: "<your Firebase app ID>",
               output_file: "tester_udids.txt",
             )
           CODE


### PR DESCRIPTION
Use examples that don't look like actual app IDs, to reduce the chances that someone copies the example verbatim and gets a 403 because they don't have access to the project.