### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/version.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FirebaseAppDistribution
-    VERSION = "0.3.2.pre.1"
+    VERSION = "0.3.2"
   end
 end


### PR DESCRIPTION
Version `0.3.2.pre.1` is looking good. This release will address https://github.com/fastlane/fastlane-plugin-firebase_app_distribution/issues/25.