### PR TITLE
Improve error messages when failing to get access token

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -18,6 +18,10 @@ module Fastlane
       def self.run(params)
         params.values # to validate all inputs before looking for the ipa/apk/aab
 
+        if params[:debug]
+          UI.important("Warning: Debug logging enabled. Output may include sensitive information.")
+        end
+
         app_id = app_id_from_params(params)
         app_name = app_name_from_app_id(app_id)
         platform = lane_platform || platform_from_app_id(app_id)

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
@@ -113,12 +113,13 @@ module Fastlane
 
       # Formats and redacts a token for printing out during debug logging. Examples:
       #   'abcd' -> '"abcd"''
-      #   'abcdef1234' -> '"abcdeXXXXX" (redacted)'
+      #   'abcdef1234' -> '"XXXXXf1234" (redacted)'
       def format_token(str)
         redaction_notice = str.length > REDACTION_EXPOSED_LENGTH ? " (redacted)" : ""
-        exposed_characters = str[0, REDACTION_EXPOSED_LENGTH]
+        exposed_start_char = [str.length - REDACTION_EXPOSED_LENGTH, 0].max
+        exposed_characters = str[exposed_start_char, REDACTION_EXPOSED_LENGTH]
         redacted_characters = REDACTION_CHARACTER * [str.length - REDACTION_EXPOSED_LENGTH, 0].max
-        "\"#{exposed_characters}#{redacted_characters}\"#{redaction_notice}"
+        "\"#{redacted_characters}#{exposed_characters}\"#{redaction_notice}"
       end
     end
   end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
@@ -4,6 +4,8 @@ module Fastlane
   module Auth
     module FirebaseAppDistributionAuthClient
       TOKEN_CREDENTIAL_URI = "https://oauth2.googleapis.com/token"
+      REDACTION_EXPOSED_LENGTH = 5
+      REDACTION_CHARACTER = "X"
 
       # Returns the auth token for any of the auth methods (Firebase CLI token,
       # Google service account, firebase-tools). To ensure that a specific
@@ -75,7 +77,8 @@ module Fastlane
       rescue Signet::AuthorizationError => error
         error_message = ErrorMessage::REFRESH_TOKEN_ERROR
         if debug
-          error_message += "\nRefresh token used: \"#{refresh_token}\"\n#{error_details(error)}"
+          error_message += "\nRefresh token used: #{format_token(refresh_token)}\n"
+          error_message += error_details(error)
         else
           error_message += " #{debug_instructions}"
         end
@@ -106,6 +109,16 @@ module Fastlane
 
       def debug_instructions
         "For more information, try again with firebase_app_distribution's \"debug\" parameter set to \"true\"."
+      end
+
+      # Formats and redacts a token for printing out during debug logging. Examples:
+      #   'abcd' -> '"abcd"''
+      #   'abcdef1234' -> '"abcdeXXXXX" (redacted)'
+      def format_token(str)
+        redaction_notice = str.length > REDACTION_EXPOSED_LENGTH ? " (redacted)" : ""
+        exposed_characters = str[0, REDACTION_EXPOSED_LENGTH]
+        redacted_characters = REDACTION_CHARACTER * [str.length - REDACTION_EXPOSED_LENGTH, 0].max
+        "\"#{exposed_characters}#{redacted_characters}\"#{redaction_notice}"
       end
     end
   end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
@@ -73,8 +73,13 @@ module Fastlane
         client.fetch_access_token!
         client.access_token
       rescue Signet::AuthorizationError => error
-        log_authorization_error_details(error) if debug
-        UI.user_error!(ErrorMessage::REFRESH_TOKEN_ERROR)
+        error_message = ErrorMessage::REFRESH_TOKEN_ERROR
+        if debug
+          error_message += "\nRefresh token used: \"#{refresh_token}\"\n#{error_details(error)}"
+        else
+          error_message += " #{debug_instructions}"
+        end
+        UI.user_error!(error_message)
       end
 
       def service_account(google_service_path, debug)
@@ -86,14 +91,21 @@ module Fastlane
       rescue Errno::ENOENT
         UI.user_error!("#{ErrorMessage::SERVICE_CREDENTIALS_NOT_FOUND}: #{google_service_path}")
       rescue Signet::AuthorizationError => error
-        log_authorization_error_details(error) if debug
-        UI.user_error!("#{ErrorMessage::SERVICE_CREDENTIALS_ERROR}: #{google_service_path}")
+        error_message = "#{ErrorMessage::SERVICE_CREDENTIALS_ERROR}: \"#{google_service_path}\""
+        if debug
+          error_message += "\n#{error_details(error)}"
+        else
+          error_message += ". #{debug_instructions}"
+        end
+        UI.user_error!(error_message)
       end
 
-      def log_authorization_error_details(error)
-        UI.error("Error fetching access token:")
-        UI.error(error.message)
-        UI.error("Response status: #{error.response.status}")
+      def error_details(error)
+        "#{error.message}\nResponse status: #{error.response.status}"
+      end
+
+      def debug_instructions
+        "For more information, try again with firebase_app_distribution's \"debug\" parameter set to \"true\"."
       end
     end
   end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
@@ -13,7 +13,7 @@ module ErrorMessage
   INVALID_PATH = "Could not read content from"
   INVALID_TESTERS = "Could not enable access for testers. Check that the groups exist and the tester emails are formatted correctly"
   INVALID_RELEASE_NOTES = "Failed to add release notes"
-  SERVICE_CREDENTIALS_ERROR = "App Distribution could not generate credentials from the service credentials file specified. Service Account Path"
+  SERVICE_CREDENTIALS_ERROR = "App Distribution could not generate credentials from the service credentials file specified"
   PLAY_ACCOUNT_NOT_LINKED = "This project is not linked to a Google Play account."
   APP_NOT_PUBLISHED = "This app is not published in the Google Play console."
   NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT = "App with matching package name does not exist in Google Play."

--- a/spec/firebase_app_distribution_auth_client_spec.rb
+++ b/spec/firebase_app_distribution_auth_client_spec.rb
@@ -101,15 +101,29 @@ describe Fastlane::Auth::FirebaseAppDistributionAuthClient do
         it 'crashes if the service credentials are invalid' do
           expect(fake_service_creds).to receive(:fetch_access_token!)
             .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
+          expect { auth_client.fetch_auth_token("invalid_service_path", empty_val, false) }
+            .to raise_error("#{ErrorMessage::SERVICE_CREDENTIALS_ERROR}: \"invalid_service_path\". For more information, try again with firebase_app_distribution's \"debug\" parameter set to \"true\".")
+        end
+
+        it 'crashes if the service credentials are invalid in debug mode' do
+          expect(fake_service_creds).to receive(:fetch_access_token!)
+            .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
           expect { auth_client.fetch_auth_token("invalid_service_path", empty_val, true) }
-            .to raise_error("#{ErrorMessage::SERVICE_CREDENTIALS_ERROR}: invalid_service_path")
+            .to raise_error("#{ErrorMessage::SERVICE_CREDENTIALS_ERROR}: \"invalid_service_path\"\nerror_message\nResponse status: 400")
         end
 
         it 'crashes if given an invalid firebase token' do
           expect(firebase_auth).to receive(:new)
             .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
+          expect { auth_client.fetch_auth_token(empty_val, "invalid_refresh_token", false) }
+            .to raise_error("#{ErrorMessage::REFRESH_TOKEN_ERROR} For more information, try again with firebase_app_distribution's \"debug\" parameter set to \"true\".")
+        end
+
+        it 'crashes if given an invalid firebase token in debug mode' do
+          expect(firebase_auth).to receive(:new)
+            .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
           expect { auth_client.fetch_auth_token(empty_val, "invalid_refresh_token", true) }
-            .to raise_error(ErrorMessage::REFRESH_TOKEN_ERROR)
+            .to raise_error("#{ErrorMessage::REFRESH_TOKEN_ERROR}\nRefresh token used: \"invalid_refresh_token\"\nerror_message\nResponse status: 400")
         end
 
         it 'crashes if the firebase tools json has no tokens field' do

--- a/spec/firebase_app_distribution_auth_client_spec.rb
+++ b/spec/firebase_app_distribution_auth_client_spec.rb
@@ -119,11 +119,18 @@ describe Fastlane::Auth::FirebaseAppDistributionAuthClient do
             .to raise_error("#{ErrorMessage::REFRESH_TOKEN_ERROR} For more information, try again with firebase_app_distribution's \"debug\" parameter set to \"true\".")
         end
 
-        it 'crashes if given an invalid firebase token in debug mode' do
+        it 'prints redacted token and error if given an invalid token in debug mode' do
           expect(firebase_auth).to receive(:new)
             .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
           expect { auth_client.fetch_auth_token(empty_val, "invalid_refresh_token", true) }
-            .to raise_error("#{ErrorMessage::REFRESH_TOKEN_ERROR}\nRefresh token used: \"invalXXXXXXXXXXXXXXXX\" (redacted)\nerror_message\nResponse status: 400")
+            .to raise_error("#{ErrorMessage::REFRESH_TOKEN_ERROR}\nRefresh token used: \"XXXXXXXXXXXXXXXXtoken\" (redacted)\nerror_message\nResponse status: 400")
+        end
+
+        it 'prints full token and error if given a short invalid token in debug mode' do
+          expect(firebase_auth).to receive(:new)
+            .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
+          expect { auth_client.fetch_auth_token(empty_val, "bad", true) }
+            .to raise_error("#{ErrorMessage::REFRESH_TOKEN_ERROR}\nRefresh token used: \"bad\"\nerror_message\nResponse status: 400")
         end
 
         it 'crashes if the firebase tools json has no tokens field' do

--- a/spec/firebase_app_distribution_auth_client_spec.rb
+++ b/spec/firebase_app_distribution_auth_client_spec.rb
@@ -123,7 +123,7 @@ describe Fastlane::Auth::FirebaseAppDistributionAuthClient do
           expect(firebase_auth).to receive(:new)
             .and_raise(Signet::AuthorizationError.new("error_message", { response: fake_error_response }))
           expect { auth_client.fetch_auth_token(empty_val, "invalid_refresh_token", true) }
-            .to raise_error("#{ErrorMessage::REFRESH_TOKEN_ERROR}\nRefresh token used: \"invalid_refresh_token\"\nerror_message\nResponse status: 400")
+            .to raise_error("#{ErrorMessage::REFRESH_TOKEN_ERROR}\nRefresh token used: \"invalXXXXXXXXXXXXXXXX\" (redacted)\nerror_message\nResponse status: 400")
         end
 
         it 'crashes if the firebase tools json has no tokens field' do


### PR DESCRIPTION
Hoping to help folks resolve their own refresh token issues (see https://github.com/fastlane/fastlane-plugin-firebase_app_distribution/issues/178). This change:
- Prompts developers to set the debug parameter to true to get more info
- In debug mode, prints out the refresh token used

Example failure using service credential file, with `debug: false`:
```
[17:40:57]: App Distribution could not generate credentials from the service credentials file specified: "/path/to/bad.json". For more information, try again with firebase_app_distribution's "debug" parameter set to "true".
```

... and `debug: true`:
```
[18:08:09]: App Distribution could not generate credentials from the service credentials file specified: "/path/to/bad.json"
Authorization failed.  Server message:
{"error":"invalid_grant","error_description":"Invalid JWT Signature."}
Response status: 400
```

Example failure using refresh token, with `debug: false`:
```
[17:24:06]: App Distribution could not generate credentials from the refresh token specified. For more information, set firebase_app_distribution's "debug" parameter to "true".
```

...and `debug: true`:
```
[17:23:25]: App Distribution could not generate credentials from the refresh token specified.
Refresh token used: "badtoken"
Authorization failed.  Server message:
{
  "error": "invalid_grant",
  "error_description": "Bad Request"
}
Response status: 400
```