### PR TITLE
Trim individual values from comma separate strings

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -24,13 +24,12 @@ module Fastlane
         value
       end
 
-      # Returns the array representation of a string with comma seperated values.
-      #
-      # Does not work with strings whose individual values have spaces. EX "Hello World" the space will be removed to "HelloWorld"
+      # Returns the array representation of a string with trimmed comma
+      # seperated values.
       def string_to_array(string)
         return nil if string.nil? || string.empty?
-        string_array = string.gsub(/\s+/, '').split(",")
-        return string_array
+        # Strip string and then strip individual values
+        string.strip.split(",").map(&:strip)
       end
 
       def parse_plist(path)

--- a/spec/firebase_app_distribution_helper_spec.rb
+++ b/spec/firebase_app_distribution_helper_spec.rb
@@ -61,8 +61,13 @@ describe Fastlane::Helper::FirebaseAppDistributionHelper do
     end
 
     it 'returns an array when the string passed in has multiple values seperated by commas' do
-      array = helper.string_to_array("string1, string2, string3")
-      expect(array).to eq(["string1", "string2", "string3"])
+      array = helper.string_to_array("string1,string2,string3")
+      expect(array).to eq(%w[string1 string2 string3])
+    end
+
+    it 'returns an array with trimmed values' do
+      array = helper.string_to_array("string1, str ing2 , string3")
+      expect(array).to eq(["string1", "str ing2", "string3"])
     end
 
     it 'returns nil if the string is undefined' do
@@ -73,6 +78,11 @@ describe Fastlane::Helper::FirebaseAppDistributionHelper do
     it 'returns nil when the string is empty' do
       array = helper.string_to_array("")
       expect(array).to eq(nil)
+    end
+
+    it 'returns empty array when the string only contains white spaces' do
+      array = helper.string_to_array(" ")
+      expect(array).to eq([])
     end
   end
 

--- a/spec/firebase_app_distribution_helper_spec.rb
+++ b/spec/firebase_app_distribution_helper_spec.rb
@@ -66,8 +66,8 @@ describe Fastlane::Helper::FirebaseAppDistributionHelper do
     end
 
     it 'returns an array with trimmed values' do
-      array = helper.string_to_array("string1, str ing2 , string3")
-      expect(array).to eq(["string1", "str ing2", "string3"])
+      array = helper.string_to_array(" string1, str ing2  ,  str  ing3 ")
+      expect(array).to eq(["string1", "str ing2", "str  ing3"])
     end
 
     it 'returns nil if the string is undefined' do


### PR DESCRIPTION
In response to #266 we should only _trim_ the whitespaces from the individual values in a comma separated string