### PR TITLE
Deprecate login action

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_login.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_login.rb
@@ -112,8 +112,8 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        "The firebase_app_distribution_login task is deprecated and will be removed in a future release. See "\
-        "https://firebase.google.com/docs/app-distribution/android/distribute-gradle#step_2_authenticate_with_firebase "\
+        "The firebase_app_distribution_login task is deprecated and will be removed in Q1 2023. See "\
+        "https://firebase.google.com/docs/app-distribution/android/distribute-gradle#authenticate "\
         "for more information on alternative ways to authenticate."
       end
     end

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_login.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_login.rb
@@ -106,6 +106,16 @@ module Fastlane
 
         ]
       end
+
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        "The firebase_app_distribution_login task is deprecated and will be removed in a future release. See "\
+        "https://firebase.google.com/docs/app-distribution/android/distribute-gradle#step_2_authenticate_with_firebase "\
+        "for more information on alternative ways to authenticate."
+      end
     end
   end
 end


### PR DESCRIPTION
Screenshot of proposed message when running `bundle exec fastlane run firebase_app_distribution_login`
![Screen Shot 2022-07-27 at 3 56 51 PM](https://user-images.githubusercontent.com/401051/181360852-b4fa4c1d-9753-439e-9788-a58f8e9db071.png)

