### PR TITLE
Add fad-icon.png to spec.files

### DIFF
--- a/fastlane-plugin-firebase_app_distribution.gemspec
+++ b/fastlane-plugin-firebase_app_distribution.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/fastlane/fastlane-plugin-firebase_app_distribution"
   spec.license       = "MIT"
 
-  spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE)
+  spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE fad-icon.png)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
Attempt to fix broken image on https://www.rubydoc.info/gems/fastlane-plugin-firebase_app_distribution/