### PR TITLE
Defined SharedVariables constant for FIREBASE_APP_DISTRO_LATEST_RELEASE

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_latest_release.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_latest_release.rb
@@ -5,6 +5,9 @@ require_relative '../helper/firebase_app_distribution_helper'
 
 module Fastlane
   module Actions
+    module SharedValues
+      FIREBASE_APP_DISTRO_LATEST_RELEASE ||= :FIREBASE_APP_DISTRO_LATEST_RELEASE
+    end
     class FirebaseAppDistributionGetLatestReleaseAction < Action
       extend Auth::FirebaseAppDistributionAuthClient
       extend Helper::FirebaseAppDistributionHelper
@@ -18,12 +21,12 @@ module Fastlane
         releases = fad_api_client.list_releases(app_name_from_app_id(params[:app]), 1)[:releases] || []
         if releases.empty?
           latest_release = nil
-          UI.important("No releases for app #{params[:app]} found in App Distribution. Returning nil and setting Actions.lane_context[:FIREBASE_APP_DISTRO_LATEST_RELEASE].")
+          UI.important("No releases for app #{params[:app]} found in App Distribution. Returning nil and setting Actions.lane_context[SharedValues::FIREBASE_APP_DISTRO_LATEST_RELEASE].")
         else
           latest_release = releases[0]
-          UI.success("✅ Latest release fetched successfully. Returning release and setting Actions.lane_context[:FIREBASE_APP_DISTRO_LATEST_RELEASE].")
+          UI.success("✅ Latest release fetched successfully. Returning release and setting Actions.lane_context[SharedValues::FIREBASE_APP_DISTRO_LATEST_RELEASE].")
         end
-        Actions.lane_context[:FIREBASE_APP_DISTRO_LATEST_RELEASE] = latest_release
+        Actions.lane_context[SharedValues::FIREBASE_APP_DISTRO_LATEST_RELEASE] = latest_release
         return latest_release
       end
 

--- a/spec/firebase_app_distribution_get_latest_release_spec.rb
+++ b/spec/firebase_app_distribution_get_latest_release_spec.rb
@@ -27,7 +27,7 @@ describe Fastlane::Actions::FirebaseAppDistributionGetLatestReleaseAction do
       allow_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:list_releases).with('projects/1234567890/apps/1:1234567890:ios:321abc456def7890', 1).and_return({ releases: [release] })
 
       expect(action.run({ app: '1:1234567890:ios:321abc456def7890' })).to eq(release)
-      expect(Fastlane::Actions.lane_context[:FIREBASE_APP_DISTRO_LATEST_RELEASE]).to eq(release)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::FIREBASE_APP_DISTRO_LATEST_RELEASE]).to eq(release)
     end
   end
 end


### PR DESCRIPTION
We document `SharedVariable::FIREBASE_APP_DISTRO_LATEST_RELEASE` but it isn't actually defined.
![image](https://user-images.githubusercontent.com/401051/218782102-70aa89d3-0198-45a6-845e-415fdeb091a7.png)

This leads to a `[!] uninitialized constant Fastlane::Actions::SharedValues::FIREBASE_APP_DISTRO_LATEST_RELEASE (NameError)` error.
