### PR TITLE
Require Ruby >= 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
+        ruby-version: ['3.2', '3.3', '3.4', '4.0']
 
     steps:
     - uses: actions/checkout@v3

--- a/fastlane-plugin-firebase_app_distribution.gemspec
+++ b/fastlane-plugin-firebase_app_distribution.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency('fastlane', '>= 2.232.0')
-  spec.add_dependency('google-apis-firebaseappdistribution_v1', '~> 0.9.0')
-  spec.add_dependency('google-apis-firebaseappdistribution_v1alpha', '~> 0.12.0')
+  spec.add_dependency('google-apis-firebaseappdistribution_v1', '>= 0.9.0')
+  spec.add_dependency('google-apis-firebaseappdistribution_v1alpha', '>= 0.12.0')
 
   spec.add_development_dependency('pry')
   spec.add_development_dependency('bundler')

--- a/lib/fastlane/plugin/firebase_app_distribution/version.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FirebaseAppDistribution
-    VERSION = "0.11.0"
+    VERSION = "1.0.0.pre.1"
   end
 end


### PR DESCRIPTION
Allow newer versions of Google API clients for App Distribution 
Update version to 1.0.0.pre.1
